### PR TITLE
Analytics page + Settings section (/settings)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -159,6 +159,15 @@ function setupHandlers() {
 				},
 			}),
 		),
+		http.get("/api/v1/analytics/supplier-pipeline", () =>
+			HttpResponse.json({
+				письмо_не_отправлено: 0,
+				ждем_ответа: 0,
+				переговоры: 0,
+				получено_кп: 0,
+				отказ: 0,
+			}),
+		),
 		http.get("/api/v1/company/tasks/board/", () =>
 			HttpResponse.json({
 				assigned: { results: [], next: null, count: 0 },

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -178,6 +178,7 @@ function setupHandlers() {
 		),
 		http.get("/api/v1/company/tasks/", () => HttpResponse.json({ count: 0, results: [], next: null, previous: null })),
 		http.get("/api/v1/company/tasks/:id/", () => HttpResponse.json({ detail: "Not found" }, { status: 404 })),
+		http.get("/api/v1/workspace/employees/", () => HttpResponse.json({ employees: [] })),
 	);
 }
 
@@ -263,7 +264,28 @@ describe("Routing", () => {
 		});
 	});
 
-	test("/profile renders profile page with skeleton then content", async () => {
+	test("/profile redirects to /settings/profile and renders profile content", async () => {
+		server.use(
+			http.get("/api/v1/auth/settings", () =>
+				HttpResponse.json({
+					first_name: "Иван",
+					last_name: "Иванов",
+					email: "ivan@example.com",
+					phone: "+79991234567",
+					avatar_icon: "blue",
+					date_joined: "2024-01-15T10:00:00Z",
+					mailing_allowed: true,
+				}),
+			),
+			http.get("/api/v1/workspace/employees/", () => HttpResponse.json({ employees: [] })),
+		);
+		renderApp(["/profile"]);
+		await waitFor(() => {
+			expect(screen.getByText("Иван Иванов")).toBeInTheDocument();
+		});
+	});
+
+	test("/settings redirects to /settings/profile", async () => {
 		server.use(
 			http.get("/api/v1/auth/settings", () =>
 				HttpResponse.json({
@@ -277,9 +299,9 @@ describe("Routing", () => {
 				}),
 			),
 		);
-		renderApp(["/profile"]);
+		renderApp(["/settings"]);
 		await waitFor(() => {
-			expect(screen.getByText("Иван Иванов")).toBeInTheDocument();
+			expect(screen.getByTestId("settings-sidebar")).toBeInTheDocument();
 		});
 	});
 
@@ -314,14 +336,15 @@ describe("Routing", () => {
 		expect(within(header).getByRole("button", { name: "Меню пользователя" })).toBeInTheDocument();
 	});
 
-	test("mobile header avatar opens dropdown with 3 items", async () => {
+	test("mobile header avatar opens dropdown with settings links", async () => {
 		renderApp();
 		const user = userEvent.setup();
 		const header = screen.getByTestId("mobile-header");
 		await user.click(within(header).getByRole("button", { name: "Меню пользователя" }));
 
 		expect(screen.getByRole("menuitem", { name: "Мой профиль" })).toBeInTheDocument();
-		expect(screen.getByRole("menuitem", { name: "Настройки" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "Компании" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "Сотрудники" })).toBeInTheDocument();
 		expect(screen.getByRole("menuitem", { name: "Выйти" })).toBeInTheDocument();
 	});
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -146,6 +146,19 @@ function setupHandlers() {
 				nextCursor: null,
 			}),
 		),
+		http.get("/api/v1/analytics/summary", () =>
+			HttpResponse.json({
+				kpis: {
+					totalSpend: 0,
+					totalOverpayment: 0,
+					totalSavings: 0,
+					completedCount: 0,
+					totalCount: 0,
+					pendingAnalysisCount: 0,
+					openTasksCount: 0,
+				},
+			}),
+		),
 		http.get("/api/v1/company/tasks/board/", () =>
 			HttpResponse.json({
 				assigned: { results: [], next: null, count: 0 },
@@ -218,12 +231,10 @@ describe("Routing", () => {
 		expect(screen.getByRole("main")).toBeInTheDocument();
 	});
 
-	test("/analytics renders placeholder page with icon", async () => {
+	test("/analytics renders analytics page", async () => {
 		renderApp(["/analytics"]);
 		await waitFor(() => {
 			expect(screen.getByRole("heading", { name: "Аналитика" })).toBeInTheDocument();
-			expect(screen.getByText("В разработке")).toBeInTheDocument();
-			expect(screen.getByTestId("placeholder-icon")).toBeInTheDocument();
 		});
 	});
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { AppLayout } from "@/components/app-layout";
 import { AuthLayout } from "@/components/auth-layout";
 import { ProtectedRoute } from "@/components/protected-route";
 import { NAV_ITEMS } from "@/lib/nav-items";
+import { AnalyticsPage } from "@/pages/analytics-page";
 import { CompaniesPage } from "@/pages/companies-page";
 import { ConfirmEmailPage } from "@/pages/confirm-email-page";
 import { ForgotPasswordPage } from "@/pages/forgot-password-page";
@@ -15,7 +16,8 @@ import { ResetPasswordPage } from "@/pages/reset-password-page";
 import { TasksPage } from "@/pages/tasks-page";
 
 const PLACEHOLDER_ROUTES = NAV_ITEMS.filter(
-	(item) => item.path !== "/procurement" && item.path !== "/tasks" && item.path !== "/companies",
+	(item) =>
+		item.path !== "/procurement" && item.path !== "/tasks" && item.path !== "/companies" && item.path !== "/analytics",
 );
 
 function RootRedirect() {
@@ -39,6 +41,7 @@ function App() {
 			<Route element={<ProtectedRoute />}>
 				<Route path="/" element={<RootRedirect />} />
 				<Route element={<AppLayout />}>
+					<Route path="/analytics" element={<AnalyticsPage />} />
 					<Route path="/procurement" element={<ProcurementPage />} />
 					<Route path="/tasks" element={<TasksPage />} />
 					<Route path="/companies" element={<CompaniesPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,14 +5,17 @@ import { ProtectedRoute } from "@/components/protected-route";
 import { NAV_ITEMS } from "@/lib/nav-items";
 import { AnalyticsPage } from "@/pages/analytics-page";
 import { CompaniesPage } from "@/pages/companies-page";
+import { CompaniesSettingsPage } from "@/pages/companies-settings-page";
 import { ConfirmEmailPage } from "@/pages/confirm-email-page";
+import { EmployeesSettingsPage } from "@/pages/employees-settings-page";
 import { ForgotPasswordPage } from "@/pages/forgot-password-page";
 import { LoginPage } from "@/pages/login-page";
 import { PlaceholderPage } from "@/pages/placeholder-page";
 import { ProcurementPage } from "@/pages/procurement-page";
-import { ProfilePage } from "@/pages/profile-page";
+import { ProfileSettingsPage } from "@/pages/profile-settings-page";
 import { RegisterPage } from "@/pages/register-page";
 import { ResetPasswordPage } from "@/pages/reset-password-page";
+import { SettingsLayout } from "@/pages/settings-layout";
 import { TasksPage } from "@/pages/tasks-page";
 
 const PLACEHOLDER_ROUTES = NAV_ITEMS.filter(
@@ -45,7 +48,15 @@ function App() {
 					<Route path="/procurement" element={<ProcurementPage />} />
 					<Route path="/tasks" element={<TasksPage />} />
 					<Route path="/companies" element={<CompaniesPage />} />
-					<Route path="/profile" element={<ProfilePage />} />
+					{/* /profile redirects to /settings/profile */}
+					<Route path="/profile" element={<Navigate to="/settings/profile" replace />} />
+					{/* Settings section */}
+					<Route path="/settings" element={<SettingsLayout />}>
+						<Route index element={<Navigate to="profile" replace />} />
+						<Route path="profile" element={<ProfileSettingsPage />} />
+						<Route path="companies" element={<CompaniesSettingsPage />} />
+						<Route path="employees" element={<EmployeesSettingsPage />} />
+					</Route>
 					{PLACEHOLDER_ROUTES.map(({ path, label, icon }) => (
 						<Route
 							key={path}

--- a/src/components/analytics-kpi-strip.test.tsx
+++ b/src/components/analytics-kpi-strip.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { AnalyticsKpis } from "@/data/analytics-types";
+import { AnalyticsKpiStrip } from "./analytics-kpi-strip";
+
+const baseKpis: AnalyticsKpis = {
+	totalSpend: 5_000_000,
+	totalOverpayment: 300_000,
+	totalSavings: 150_000,
+	completedCount: 8,
+	totalCount: 20,
+	pendingAnalysisCount: 4,
+	openTasksCount: 3,
+};
+
+describe("AnalyticsKpiStrip", () => {
+	it("renders all 5 KPI labels", () => {
+		render(<AnalyticsKpiStrip kpis={baseKpis} />);
+
+		expect(screen.getByText("Годовые затраты")).toBeInTheDocument();
+		expect(screen.getByText("Переплата")).toBeInTheDocument();
+		expect(screen.getByText("Экономия")).toBeInTheDocument();
+		expect(screen.getByText("Выполнено")).toBeInTheDocument();
+		expect(screen.getByText("Открытые задачи")).toBeInTheDocument();
+	});
+
+	it("renders completed count, total count, and percentage", () => {
+		render(<AnalyticsKpiStrip kpis={baseKpis} />);
+
+		// 8 completed out of 20 = 40%
+		expect(screen.getByText("8")).toBeInTheDocument();
+		expect(screen.getByText(/из 20/)).toBeInTheDocument();
+		expect(screen.getByText("40%")).toBeInTheDocument();
+	});
+
+	it("renders open tasks count", () => {
+		render(<AnalyticsKpiStrip kpis={baseKpis} />);
+		expect(screen.getByText("3")).toBeInTheDocument();
+	});
+
+	it("renders currency values", () => {
+		render(<AnalyticsKpiStrip kpis={baseKpis} />);
+
+		// Currency values contain ₽ symbol
+		const roubleTexts = screen.getAllByText(/₽/);
+		expect(roubleTexts.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it("shows pending analysis footnote when pendingAnalysisCount > 0", () => {
+		render(<AnalyticsKpiStrip kpis={baseKpis} />);
+		expect(screen.getByText(/не проанализировано/)).toBeInTheDocument();
+	});
+
+	it("hides pending analysis footnote when pendingAnalysisCount is 0", () => {
+		render(<AnalyticsKpiStrip kpis={{ ...baseKpis, pendingAnalysisCount: 0 }} />);
+		expect(screen.queryByText(/не проанализировано/)).not.toBeInTheDocument();
+	});
+
+	it("shows 0% completed when totalCount is 0", () => {
+		render(<AnalyticsKpiStrip kpis={{ ...baseKpis, completedCount: 0, totalCount: 0 }} />);
+		expect(screen.getByText("0%")).toBeInTheDocument();
+	});
+});

--- a/src/components/analytics-kpi-strip.tsx
+++ b/src/components/analytics-kpi-strip.tsx
@@ -1,0 +1,73 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { AnalyticsKpis } from "@/data/analytics-types";
+import { formatCurrency, pluralizeRu } from "@/lib/format";
+
+interface Props {
+	kpis: AnalyticsKpis;
+}
+
+export function AnalyticsKpiStrip({ kpis }: Props) {
+	const completedPct = kpis.totalCount > 0 ? Math.round((kpis.completedCount / kpis.totalCount) * 100) : 0;
+
+	return (
+		<div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+			<Card>
+				<CardHeader>
+					<CardTitle>Годовые затраты</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<p className="text-2xl font-bold tabular-nums">{formatCurrency(kpis.totalSpend)}</p>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Переплата</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<p className="text-2xl font-bold tabular-nums text-red-600 dark:text-red-400">
+						{formatCurrency(kpis.totalOverpayment)}
+					</p>
+					{kpis.pendingAnalysisCount > 0 && (
+						<p className="mt-1 text-xs text-muted-foreground">
+							{pluralizeRu(kpis.pendingAnalysisCount, "позиция", "позиции", "позиций")} не проанализировано
+						</p>
+					)}
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Экономия</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<p className="text-2xl font-bold tabular-nums text-green-600 dark:text-green-400">
+						{formatCurrency(kpis.totalSavings)}
+					</p>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Выполнено</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<p className="text-2xl font-bold tabular-nums">
+						{kpis.completedCount}{" "}
+						<span className="text-base font-normal text-muted-foreground">из {kpis.totalCount}</span>
+					</p>
+					<p className="text-xs text-muted-foreground">{completedPct}%</p>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Открытые задачи</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<p className="text-2xl font-bold tabular-nums">{kpis.openTasksCount}</p>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/src/components/analytics-tasks-summary.test.tsx
+++ b/src/components/analytics-tasks-summary.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+import { AnalyticsTasksSummary } from "./analytics-tasks-summary";
+
+describe("AnalyticsTasksSummary", () => {
+	it("renders open and overdue counts", () => {
+		render(
+			<MemoryRouter>
+				<AnalyticsTasksSummary tasksSummary={{ open: 7, overdue: 3 }} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("7")).toBeInTheDocument();
+		expect(screen.getByText("3")).toBeInTheDocument();
+	});
+
+	it("renders the card heading", () => {
+		render(
+			<MemoryRouter>
+				<AnalyticsTasksSummary tasksSummary={{ open: 0, overdue: 0 }} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Задачи")).toBeInTheDocument();
+	});
+
+	it("contains a link to the tasks page", () => {
+		render(
+			<MemoryRouter>
+				<AnalyticsTasksSummary tasksSummary={{ open: 5, overdue: 1 }} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByRole("link")).toHaveAttribute("href", "/tasks");
+	});
+});

--- a/src/components/analytics-tasks-summary.tsx
+++ b/src/components/analytics-tasks-summary.tsx
@@ -1,0 +1,36 @@
+import { Link } from "react-router";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface Props {
+	tasksSummary: { open: number; overdue: number };
+}
+
+export function AnalyticsTasksSummary({ tasksSummary }: Props) {
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Задачи</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<div className="grid grid-cols-2 gap-4">
+					<div>
+						<p className="text-sm text-muted-foreground">Открытые</p>
+						<p className="text-2xl font-bold tabular-nums">{tasksSummary.open}</p>
+					</div>
+					<div>
+						<p className="text-sm text-muted-foreground">Просроченные</p>
+						<p className="text-destructive text-2xl font-bold tabular-nums">{tasksSummary.overdue}</p>
+					</div>
+				</div>
+				<div className="mt-4">
+					<Link
+						to="/tasks"
+						className="text-primary text-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					>
+						Перейти к задачам →
+					</Link>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/components/app-sidebar.test.tsx
+++ b/src/components/app-sidebar.test.tsx
@@ -114,14 +114,15 @@ describe("User avatar dropdown", () => {
 		expect(screen.getByRole("button", { name: "Меню пользователя" })).toBeInTheDocument();
 	});
 
-	test("clicking avatar opens dropdown with 3 items", async () => {
+	test("clicking avatar opens dropdown with settings links", async () => {
 		renderSidebar();
 		const user = userEvent.setup();
 
 		await user.click(screen.getByRole("button", { name: "Меню пользователя" }));
 
 		expect(screen.getByRole("menuitem", { name: "Мой профиль" })).toBeInTheDocument();
-		expect(screen.getByRole("menuitem", { name: "Настройки" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "Компании" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "Сотрудники" })).toBeInTheDocument();
 		expect(screen.getByRole("menuitem", { name: "Выйти" })).toBeInTheDocument();
 	});
 

--- a/src/components/employee-detail-drawer.test.tsx
+++ b/src/components/employee-detail-drawer.test.tsx
@@ -1,0 +1,114 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { WorkspaceEmployee } from "@/data/workspace-types";
+import { server } from "@/test-msw";
+import { createTestQueryClient } from "@/test-utils";
+import { EmployeeDetailDrawer } from "./employee-detail-drawer";
+
+let queryClient: QueryClient;
+
+const mockEmployee: WorkspaceEmployee = {
+	id: 1,
+	firstName: "Иван",
+	lastName: "Иванов",
+	patronymic: "Иванович",
+	position: "Директор",
+	role: "admin",
+	phone: "+79991234567",
+	email: "ivan@example.com",
+	companies: [{ id: "co-1", name: "Альфа" }],
+	registeredAt: "2024-01-15T10:00:00Z",
+	permissions: {
+		id: "perm-1",
+		employeeId: 1,
+		analytics: "edit",
+		procurement: "view",
+		companies: "none",
+		tasks: "edit",
+	},
+};
+
+beforeEach(() => {
+	queryClient = createTestQueryClient();
+	server.use(
+		http.patch("/api/v1/workspace/employees/:id/permissions/", () =>
+			HttpResponse.json({ ...mockEmployee.permissions, analytics: "none" }),
+		),
+	);
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+function renderDrawer(employee: WorkspaceEmployee | null = mockEmployee) {
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<MemoryRouter>
+				<TooltipProvider>
+					<EmployeeDetailDrawer employee={employee} onClose={() => {}} />
+				</TooltipProvider>
+			</MemoryRouter>
+		</QueryClientProvider>,
+	);
+}
+
+describe("EmployeeDetailDrawer", () => {
+	test("renders drawer with employee name as title when open", async () => {
+		renderDrawer();
+		expect(screen.getByText("Иванов Иван Иванович")).toBeInTheDocument();
+	});
+
+	test("Информация tab shows employee email and position", async () => {
+		renderDrawer();
+		expect(screen.getByText("ivan@example.com")).toBeInTheDocument();
+		expect(screen.getByText("Директор")).toBeInTheDocument();
+	});
+
+	test("Права доступа tab shows permissions matrix", async () => {
+		const user = userEvent.setup();
+		renderDrawer();
+		await user.click(screen.getByRole("tab", { name: "Права доступа" }));
+		expect(screen.getByTestId("permissions-matrix")).toBeInTheDocument();
+	});
+
+	test("permission change fires update mutation", async () => {
+		const user = userEvent.setup();
+		let patchBody: unknown;
+		server.use(
+			http.patch("/api/v1/workspace/employees/:id/permissions/", async ({ request }) => {
+				patchBody = await request.json();
+				return HttpResponse.json(mockEmployee.permissions);
+			}),
+		);
+
+		// Use non-privileged role so edit button is visible
+		renderDrawer({ ...mockEmployee, role: "user" });
+		await user.click(screen.getByRole("tab", { name: "Права доступа" }));
+
+		// Click edit on permissions matrix
+		const editBtn = screen.getByRole("button", { name: "Редактировать права доступа" });
+		await user.click(editBtn);
+
+		// Click "Нет" (none) for analytics
+		await user.click(screen.getByTestId("perm-analytics-none"));
+
+		// Click "Готово" to save
+		await user.click(screen.getByRole("button", { name: "Готово" }));
+
+		await waitFor(() => {
+			expect(patchBody).toEqual(expect.objectContaining({ analytics: "none" }));
+		});
+	});
+
+	test("does not render when employee is null", () => {
+		renderDrawer(null);
+		expect(screen.queryByText("Иванов Иван Иванович")).not.toBeInTheDocument();
+	});
+});

--- a/src/components/employee-detail-drawer.tsx
+++ b/src/components/employee-detail-drawer.tsx
@@ -10,6 +10,8 @@ import type { EmployeePermissions, PermissionLevel } from "@/data/types";
 import { PRIVILEGED_ROLES, ROLE_LABELS } from "@/data/types";
 import { useUpdateWorkspaceEmployeePermissions } from "@/data/use-workspace";
 import type { WorkspaceEmployee } from "@/data/workspace-types";
+import { formatEmployeeFullName } from "@/lib/format";
+import { cn } from "@/lib/utils";
 
 type EmployeeTab = "info" | "permissions";
 
@@ -41,12 +43,6 @@ const PERM_COLOR: Record<PermissionLevel, string> = {
 	none: "text-red-500/60 dark:text-red-400/60",
 };
 
-const PERMISSION_LEVEL_LABELS: Record<PermissionLevel, string> = {
-	none: "Нет доступа",
-	view: "Просмотр",
-	edit: "Редактирование",
-};
-
 function PermissionSegments({
 	value,
 	onChange,
@@ -63,9 +59,10 @@ function PermissionSegments({
 					key={lvl.value}
 					type="button"
 					aria-pressed={value === lvl.value}
-					className={`px-2 py-1 transition-colors first:rounded-l-md last:rounded-r-md border-r last:border-r-0 border-border ${
-						value === lvl.value ? "bg-primary text-primary-foreground" : "hover:bg-muted"
-					}`}
+					className={cn(
+						"border-r border-border px-2 py-1 transition-colors first:rounded-l-md last:rounded-r-md last:border-r-0",
+						value === lvl.value ? "bg-primary text-primary-foreground" : "hover:bg-muted",
+					)}
 					onClick={() => onChange(lvl.value)}
 					data-testid={`perm-${moduleKey}-${lvl.value}`}
 				>
@@ -119,7 +116,7 @@ function PermissionsMatrix({
 								</div>
 							</TooltipTrigger>
 							<TooltipContent side="bottom" className="text-xs">
-								{mod.label}: {PERMISSION_LEVEL_LABELS[level]}
+								{mod.label}: {PERMISSION_LEVELS.find((l) => l.value === level)?.label}
 							</TooltipContent>
 						</Tooltip>
 					);
@@ -167,10 +164,6 @@ function PermissionsMatrix({
 	);
 }
 
-function fullName(emp: WorkspaceEmployee): string {
-	return [emp.lastName, emp.firstName, emp.patronymic].filter(Boolean).join(" ");
-}
-
 interface EmployeeDetailDrawerProps {
 	employee: WorkspaceEmployee | null;
 	onClose: () => void;
@@ -193,7 +186,7 @@ export function EmployeeDetailDrawer({ employee, onClose }: EmployeeDetailDrawer
 				{employee && (
 					<>
 						<SheetHeader>
-							<SheetTitle>{fullName(employee)}</SheetTitle>
+							<SheetTitle>{formatEmployeeFullName(employee)}</SheetTitle>
 							<SheetDescription className="sr-only">Детали сотрудника</SheetDescription>
 						</SheetHeader>
 
@@ -204,11 +197,12 @@ export function EmployeeDetailDrawer({ employee, onClose }: EmployeeDetailDrawer
 									type="button"
 									role="tab"
 									aria-selected={activeTab === tab.key}
-									className={`shrink-0 whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors ${
+									className={cn(
+										"shrink-0 whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors",
 										activeTab === tab.key
 											? "border-b-2 border-primary text-foreground"
-											: "text-muted-foreground hover:text-foreground"
-									}`}
+											: "text-muted-foreground hover:text-foreground",
+									)}
 									onClick={() => setActiveTab(tab.key)}
 									data-testid={`emp-tab-${tab.key}`}
 								>

--- a/src/components/employee-detail-drawer.tsx
+++ b/src/components/employee-detail-drawer.tsx
@@ -1,0 +1,255 @@
+import type { LucideIcon } from "lucide-react";
+import { Building2, Layers, LayoutDashboard, ListTodo, LoaderCircle, Pencil } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ViewField } from "@/components/view-field";
+import type { EmployeePermissions, PermissionLevel } from "@/data/types";
+import { PRIVILEGED_ROLES, ROLE_LABELS } from "@/data/types";
+import { useUpdateWorkspaceEmployeePermissions } from "@/data/use-workspace";
+import type { WorkspaceEmployee } from "@/data/workspace-types";
+
+type EmployeeTab = "info" | "permissions";
+
+const TABS: { key: EmployeeTab; label: string }[] = [
+	{ key: "info", label: "Информация" },
+	{ key: "permissions", label: "Права доступа" },
+];
+
+const PERMISSION_MODULES: {
+	key: keyof Omit<EmployeePermissions, "id" | "employeeId">;
+	label: string;
+	Icon: LucideIcon;
+}[] = [
+	{ key: "analytics", label: "Аналитика", Icon: LayoutDashboard },
+	{ key: "procurement", label: "Закупки", Icon: Layers },
+	{ key: "companies", label: "Компании", Icon: Building2 },
+	{ key: "tasks", label: "Задачи", Icon: ListTodo },
+];
+
+const PERMISSION_LEVELS: { value: PermissionLevel; label: string }[] = [
+	{ value: "none", label: "Нет доступа" },
+	{ value: "view", label: "Просмотр" },
+	{ value: "edit", label: "Редактирование" },
+];
+
+const PERM_COLOR: Record<PermissionLevel, string> = {
+	edit: "text-green-600 dark:text-green-400",
+	view: "text-yellow-600 dark:text-yellow-400",
+	none: "text-red-500/60 dark:text-red-400/60",
+};
+
+const PERMISSION_LEVEL_LABELS: Record<PermissionLevel, string> = {
+	none: "Нет доступа",
+	view: "Просмотр",
+	edit: "Редактирование",
+};
+
+function PermissionSegments({
+	value,
+	onChange,
+	moduleKey,
+}: {
+	value: PermissionLevel;
+	onChange: (level: PermissionLevel) => void;
+	moduleKey: string;
+}) {
+	return (
+		<div className="inline-flex rounded-md border border-border text-xs">
+			{PERMISSION_LEVELS.map((lvl) => (
+				<button
+					key={lvl.value}
+					type="button"
+					aria-pressed={value === lvl.value}
+					className={`px-2 py-1 transition-colors first:rounded-l-md last:rounded-r-md border-r last:border-r-0 border-border ${
+						value === lvl.value ? "bg-primary text-primary-foreground" : "hover:bg-muted"
+					}`}
+					onClick={() => onChange(lvl.value)}
+					data-testid={`perm-${moduleKey}-${lvl.value}`}
+				>
+					{lvl.label}
+				</button>
+			))}
+		</div>
+	);
+}
+
+function PermissionsMatrix({
+	permissions,
+	employeeId,
+	readOnly = false,
+}: {
+	permissions: EmployeePermissions;
+	employeeId: number;
+	readOnly?: boolean;
+}) {
+	const [editing, setEditing] = useState(false);
+	const [localPerms, setLocalPerms] = useState<EmployeePermissions>(permissions);
+	const updateMutation = useUpdateWorkspaceEmployeePermissions(employeeId);
+
+	function handleChange(module: keyof Omit<EmployeePermissions, "id" | "employeeId">, level: PermissionLevel) {
+		setLocalPerms((prev) => ({ ...prev, [module]: level }));
+	}
+
+	function handleDone() {
+		const changed: Partial<EmployeePermissions> = {};
+		for (const mod of PERMISSION_MODULES) {
+			if (localPerms[mod.key] !== permissions[mod.key]) {
+				changed[mod.key] = localPerms[mod.key];
+			}
+		}
+		if (Object.keys(changed).length > 0) {
+			updateMutation.mutate(changed);
+		}
+		setEditing(false);
+	}
+
+	if (!editing) {
+		return (
+			<div className="flex items-center gap-2" data-testid="permissions-matrix">
+				{PERMISSION_MODULES.map((mod) => {
+					const level = localPerms[mod.key];
+					return (
+						<Tooltip key={mod.key}>
+							<TooltipTrigger asChild>
+								<div className="p-1.5 rounded-md bg-muted/50" data-testid={`perm-row-${mod.key}`}>
+									<mod.Icon className={`size-5 ${PERM_COLOR[level]}`} aria-hidden="true" />
+								</div>
+							</TooltipTrigger>
+							<TooltipContent side="bottom" className="text-xs">
+								{mod.label}: {PERMISSION_LEVEL_LABELS[level]}
+							</TooltipContent>
+						</Tooltip>
+					);
+				})}
+				{!readOnly && (
+					<button
+						type="button"
+						className="inline-flex items-center justify-center size-6 rounded text-muted-foreground/60 hover:text-foreground transition-colors ml-0.5"
+						onClick={() => setEditing(true)}
+						aria-label="Редактировать права доступа"
+					>
+						<Pencil className="size-3" aria-hidden="true" />
+					</button>
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className="inline-flex flex-col gap-3 rounded-lg border border-border p-3 self-start"
+			data-testid="permissions-matrix"
+		>
+			{PERMISSION_MODULES.map((mod) => {
+				const level = localPerms[mod.key];
+				return (
+					<div key={mod.key} className="flex flex-col gap-1.5" data-testid={`perm-row-${mod.key}`}>
+						<div className="flex items-center gap-1.5">
+							<mod.Icon className={`size-4 ${PERM_COLOR[level]}`} aria-hidden="true" />
+							<span className="text-xs font-medium">{mod.label}</span>
+						</div>
+						<PermissionSegments value={level} onChange={(l) => handleChange(mod.key, l)} moduleKey={mod.key} />
+					</div>
+				);
+			})}
+			<div className="flex justify-end gap-2">
+				{updateMutation.isPending && (
+					<LoaderCircle className="size-4 animate-spin text-muted-foreground self-center" aria-label="Сохранение…" />
+				)}
+				<Button type="button" variant="outline" size="sm" onClick={handleDone}>
+					Готово
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function fullName(emp: WorkspaceEmployee): string {
+	return [emp.lastName, emp.firstName, emp.patronymic].filter(Boolean).join(" ");
+}
+
+interface EmployeeDetailDrawerProps {
+	employee: WorkspaceEmployee | null;
+	onClose: () => void;
+}
+
+export function EmployeeDetailDrawer({ employee, onClose }: EmployeeDetailDrawerProps) {
+	const [activeTab, setActiveTab] = useState<EmployeeTab>("info");
+
+	return (
+		<Sheet
+			open={employee !== null}
+			onOpenChange={(next) => {
+				if (!next) onClose();
+			}}
+		>
+			<SheetContent
+				className="flex flex-col max-md:!w-full max-md:!max-w-full max-md:!inset-0 max-md:!rounded-none"
+				data-testid="employee-detail-drawer"
+			>
+				{employee && (
+					<>
+						<SheetHeader>
+							<SheetTitle>{fullName(employee)}</SheetTitle>
+							<SheetDescription className="sr-only">Детали сотрудника</SheetDescription>
+						</SheetHeader>
+
+						<div className="flex gap-0 overflow-x-auto border-b border-border px-4" role="tablist">
+							{TABS.map((tab) => (
+								<button
+									key={tab.key}
+									type="button"
+									role="tab"
+									aria-selected={activeTab === tab.key}
+									className={`shrink-0 whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors ${
+										activeTab === tab.key
+											? "border-b-2 border-primary text-foreground"
+											: "text-muted-foreground hover:text-foreground"
+									}`}
+									onClick={() => setActiveTab(tab.key)}
+									data-testid={`emp-tab-${tab.key}`}
+								>
+									{tab.label}
+								</button>
+							))}
+						</div>
+
+						<div className="flex-1 overflow-y-auto px-4 py-4">
+							{activeTab === "info" && (
+								<div className="grid grid-cols-2 gap-x-4 gap-y-3">
+									<ViewField label="Фамилия" value={employee.lastName} />
+									<ViewField label="Имя" value={employee.firstName} />
+									<ViewField label="Отчество" value={employee.patronymic || "—"} />
+									<ViewField label="Должность" value={employee.position} />
+									<ViewField label="Электронная почта" value={employee.email} />
+									<ViewField label="Телефон" value={employee.phone} />
+									<ViewField label="Роль" value={ROLE_LABELS[employee.role]} />
+									<div className="col-span-2">
+										<ViewField label="Компании" value={employee.companies.map((c) => c.name).join(", ") || "—"} />
+									</div>
+								</div>
+							)}
+
+							{activeTab === "permissions" && (
+								<div className="flex flex-col gap-3">
+									<Separator />
+									<div className="flex flex-col gap-2">
+										<h4 className="text-xs font-medium text-muted-foreground">Права доступа</h4>
+										<PermissionsMatrix
+											permissions={employee.permissions}
+											employeeId={employee.id}
+											readOnly={PRIVILEGED_ROLES.has(employee.role)}
+										/>
+									</div>
+								</div>
+							)}
+						</div>
+					</>
+				)}
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/src/components/folder-overpayment-chart.test.tsx
+++ b/src/components/folder-overpayment-chart.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { FolderBreakdown } from "@/data/analytics-types";
+import { FolderOverpaymentChart } from "./folder-overpayment-chart";
+
+// Mock ResponsiveContainer to avoid jsdom sizing issues
+vi.mock("recharts", async () => {
+	const actual = await vi.importActual<typeof import("recharts")>("recharts");
+	return {
+		...actual,
+		ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+			<div data-testid="responsive-container" style={{ width: 320, height: 200 }}>
+				{children}
+			</div>
+		),
+	};
+});
+
+const mockFolderBreakdown: FolderBreakdown[] = [
+	{ folderId: "f1", folderName: "Электроника", overpayment: 200_000, deviationPct: 18 },
+	{ folderId: "f2", folderName: "Мебель", overpayment: 80_000, deviationPct: 10 },
+	{ folderId: "f3", folderName: "Оргтехника", overpayment: 30_000, deviationPct: 5 },
+];
+
+describe("FolderOverpaymentChart", () => {
+	it("renders folder names from breakdown data", () => {
+		render(<FolderOverpaymentChart folderBreakdown={mockFolderBreakdown} />);
+		expect(screen.getByText("Электроника")).toBeInTheDocument();
+		expect(screen.getByText("Мебель")).toBeInTheDocument();
+		expect(screen.getByText("Оргтехника")).toBeInTheDocument();
+	});
+
+	it("renders overpayment ₽ values for each folder", () => {
+		render(<FolderOverpaymentChart folderBreakdown={mockFolderBreakdown} />);
+		// formatCurrency renders values with ₽ symbol
+		expect(screen.getByText(/200\s*000/)).toBeInTheDocument();
+		expect(screen.getByText(/80\s*000/)).toBeInTheDocument();
+		expect(screen.getByText(/30\s*000/)).toBeInTheDocument();
+	});
+
+	it("renders empty state when folderBreakdown is empty", () => {
+		render(<FolderOverpaymentChart folderBreakdown={[]} />);
+		expect(screen.getByTestId("folder-chart-empty")).toBeInTheDocument();
+		expect(screen.queryByTestId("folder-chart-legend")).not.toBeInTheDocument();
+	});
+
+	it("renders section heading", () => {
+		render(<FolderOverpaymentChart folderBreakdown={mockFolderBreakdown} />);
+		expect(screen.getByText("Переплата по папкам")).toBeInTheDocument();
+	});
+});

--- a/src/components/folder-overpayment-chart.tsx
+++ b/src/components/folder-overpayment-chart.tsx
@@ -1,0 +1,64 @@
+import { Bar, BarChart, LabelList, XAxis, YAxis } from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import type { FolderBreakdown } from "@/data/analytics-types";
+import { formatCurrency, formatDeviation } from "@/lib/format";
+
+const chartConfig: ChartConfig = {
+	overpayment: { label: "Переплата", color: "oklch(0.65 0.22 25)" },
+};
+
+interface Props {
+	folderBreakdown: FolderBreakdown[];
+}
+
+export function FolderOverpaymentChart({ folderBreakdown }: Props) {
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Переплата по папкам</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{folderBreakdown.length === 0 ? (
+					<p data-testid="folder-chart-empty" className="py-8 text-center text-sm text-muted-foreground">
+						Нет данных — установите лучшую цену хотя бы для одной позиции
+					</p>
+				) : (
+					<>
+						<ChartContainer
+							config={chartConfig}
+							style={{ height: Math.max(folderBreakdown.length * 48 + 48, 120) }}
+							className="w-full"
+						>
+							<BarChart layout="vertical" data={folderBreakdown} margin={{ right: 80, left: 8 }}>
+								<YAxis dataKey="folderName" type="category" width={0} tick={false} axisLine={false} />
+								<XAxis type="number" hide />
+								<ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+								<Bar dataKey="overpayment" fill="var(--color-overpayment)" radius={4}>
+									<LabelList
+										dataKey="deviationPct"
+										position="right"
+										formatter={(v: unknown) => formatDeviation(typeof v === "number" ? v : null).text}
+										className="fill-muted-foreground text-xs"
+									/>
+								</Bar>
+							</BarChart>
+						</ChartContainer>
+						<div data-testid="folder-chart-legend" className="mt-4 flex flex-col gap-2">
+							{folderBreakdown.map((item) => {
+								const dev = formatDeviation(item.deviationPct);
+								return (
+									<div key={item.folderId} className="flex items-center gap-3 text-sm">
+										<span className="min-w-0 flex-1 truncate">{item.folderName}</span>
+										<span className="tabular-nums font-semibold">{formatCurrency(item.overpayment)}</span>
+										<span className={dev.className}>{dev.text}</span>
+									</div>
+								);
+							})}
+						</div>
+					</>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/components/folder-sidebar.tsx
+++ b/src/components/folder-sidebar.tsx
@@ -38,10 +38,11 @@ import { nextUnusedColor } from "@/data/use-folders";
 import { useInlineEdit } from "@/hooks/use-inline-edit";
 import { useMenuEditGuard } from "@/hooks/use-menu-edit-guard";
 import { useMountEffect } from "@/hooks/use-mount-effect";
+import { DESKTOP_QUERY } from "@/lib/breakpoints";
 import { cn } from "@/lib/utils";
 
 export const LS_SIDEBAR_KEY = "sidebar-open";
-export const DESKTOP_QUERY = "(min-width: 1024px)";
+export { DESKTOP_QUERY };
 
 function navItemClassName(active: boolean, isOver = false, extra?: string) {
 	return cn(

--- a/src/components/invite-employees-drawer.test.tsx
+++ b/src/components/invite-employees-drawer.test.tsx
@@ -1,0 +1,90 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { server } from "@/test-msw";
+import { createTestQueryClient, makeCompany } from "@/test-utils";
+import { InviteEmployeesDrawer } from "./invite-employees-drawer";
+
+let queryClient: QueryClient;
+
+beforeEach(() => {
+	queryClient = createTestQueryClient();
+	server.use(
+		http.get("/api/v1/companies/", () =>
+			HttpResponse.json({
+				companies: [makeCompany("co-1", { name: "Альфа" }), makeCompany("co-2", { name: "Бета" })],
+				nextCursor: null,
+			}),
+		),
+		http.post("/api/v1/workspace/employees/invite/", () => new HttpResponse(null, { status: 201 })),
+	);
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+function renderDrawer(open = true) {
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<MemoryRouter>
+				<InviteEmployeesDrawer open={open} onOpenChange={() => {}} />
+			</MemoryRouter>
+		</QueryClientProvider>,
+	);
+}
+
+describe("InviteEmployeesDrawer", () => {
+	test("renders drawer title", () => {
+		renderDrawer();
+		expect(screen.getByText("Отправить приглашения")).toBeInTheDocument();
+	});
+
+	test("starts with one invite card", () => {
+		renderDrawer();
+		// One email input field visible
+		expect(screen.getAllByLabelText("Электронная почта")).toHaveLength(1);
+	});
+
+	test("clicking + Добавить appends a card", async () => {
+		const user = userEvent.setup();
+		renderDrawer();
+		await user.click(screen.getByRole("button", { name: "+ Добавить" }));
+		expect(screen.getAllByLabelText("Электронная почта")).toHaveLength(2);
+	});
+
+	test("submit fires bulk invite POST request", async () => {
+		const user = userEvent.setup();
+		let capturedBody: unknown;
+		server.use(
+			http.post("/api/v1/workspace/employees/invite/", async ({ request }) => {
+				capturedBody = await request.json();
+				return new HttpResponse(null, { status: 201 });
+			}),
+		);
+
+		renderDrawer();
+
+		await user.type(screen.getByLabelText("Электронная почта"), "new@example.com");
+		await user.type(screen.getByLabelText("Должность"), "Менеджер");
+
+		await user.click(screen.getByRole("button", { name: "Отправить" }));
+
+		await waitFor(() => {
+			expect(capturedBody).toEqual(
+				expect.objectContaining({
+					invites: expect.arrayContaining([expect.objectContaining({ email: "new@example.com" })]),
+				}),
+			);
+		});
+	});
+
+	test("does not render when closed", () => {
+		renderDrawer(false);
+		expect(screen.queryByText("Отправить приглашения")).not.toBeInTheDocument();
+	});
+});

--- a/src/components/invite-employees-drawer.tsx
+++ b/src/components/invite-employees-drawer.tsx
@@ -1,0 +1,153 @@
+import { Loader2, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { FloatingInput } from "@/components/floating-input";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { ASSIGNABLE_ROLES, ROLE_LABELS } from "@/data/types";
+import { useInviteEmployees } from "@/data/use-workspace";
+import type { InvitePayload } from "@/data/workspace-types";
+
+interface InviteCard {
+	id: string;
+	email: string;
+	position: string;
+	role: "admin" | "user";
+}
+
+function makeCard(): InviteCard {
+	return { id: crypto.randomUUID(), email: "", position: "", role: "user" };
+}
+
+interface InviteEmployeesDrawerProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+export function InviteEmployeesDrawer({ open, onOpenChange }: InviteEmployeesDrawerProps) {
+	const [cards, setCards] = useState<InviteCard[]>(() => [makeCard()]);
+	const inviteMutation = useInviteEmployees();
+
+	function addCard() {
+		setCards((prev) => [...prev, makeCard()]);
+	}
+
+	function removeCard(id: string) {
+		setCards((prev) => prev.filter((c) => c.id !== id));
+	}
+
+	function updateCard(id: string, field: keyof Omit<InviteCard, "id">, value: string) {
+		setCards((prev) => prev.map((c) => (c.id === id ? { ...c, [field]: value } : c)));
+	}
+
+	function handleClose() {
+		setCards([makeCard()]);
+		onOpenChange(false);
+	}
+
+	function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		const invites: InvitePayload[] = cards
+			.filter((c) => c.email.trim())
+			.map((c) => ({ email: c.email.trim(), position: c.position, role: c.role, companies: [] }));
+
+		if (invites.length === 0) return;
+
+		inviteMutation.mutate(invites, {
+			onSuccess: () => {
+				toast.success("Приглашения отправлены");
+				handleClose();
+			},
+			onError: () => {
+				toast.error("Не удалось отправить приглашения");
+			},
+		});
+	}
+
+	return (
+		<Sheet
+			open={open}
+			onOpenChange={(next) => {
+				if (!next) handleClose();
+			}}
+		>
+			<SheetContent className="flex flex-col max-md:!w-full max-md:!max-w-full max-md:!inset-0 max-md:!rounded-none">
+				<SheetHeader>
+					<SheetTitle>Отправить приглашения</SheetTitle>
+					<SheetDescription className="sr-only">Добавить новых сотрудников</SheetDescription>
+				</SheetHeader>
+
+				<form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-hidden">
+					<div className="flex-1 overflow-y-auto px-1 py-2 space-y-3">
+						{cards.map((card, index) => (
+							<div key={card.id} className="rounded-lg border border-border p-3 space-y-3">
+								<div className="flex items-center justify-between">
+									<span className="text-sm font-medium text-muted-foreground">Сотрудник {index + 1}</span>
+									{cards.length > 1 && (
+										<button
+											type="button"
+											onClick={() => removeCard(card.id)}
+											aria-label="Удалить карточку"
+											className="text-muted-foreground hover:text-destructive transition-colors"
+										>
+											<Trash2 className="size-4" aria-hidden="true" />
+										</button>
+									)}
+								</div>
+								<FloatingInput
+									label="Электронная почта"
+									name={`email-${card.id}`}
+									type="email"
+									value={card.email}
+									onChange={(e) => updateCard(card.id, "email", e.target.value)}
+									autoComplete="off"
+									aria-label="Электронная почта"
+								/>
+								<FloatingInput
+									label="Должность"
+									name={`position-${card.id}`}
+									value={card.position}
+									onChange={(e) => updateCard(card.id, "position", e.target.value)}
+									autoComplete="off"
+									aria-label="Должность"
+								/>
+								<div>
+									<label htmlFor={`role-${card.id}`} className="mb-1 block text-xs text-muted-foreground">
+										Роль
+									</label>
+									<Select value={card.role} onValueChange={(v) => updateCard(card.id, "role", v)}>
+										<SelectTrigger id={`role-${card.id}`} className="w-full">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{ASSIGNABLE_ROLES.map((role) => (
+												<SelectItem key={role} value={role}>
+													{ROLE_LABELS[role]}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+							</div>
+						))}
+
+						<Button type="button" variant="outline" size="sm" className="w-full" onClick={addCard}>
+							+ Добавить
+						</Button>
+					</div>
+
+					<div className="shrink-0 border-t border-border px-1 pt-3 pb-1 flex justify-end gap-2">
+						<Button type="button" variant="outline" onClick={handleClose}>
+							Отмена
+						</Button>
+						<Button type="submit" disabled={inviteMutation.isPending || cards.every((c) => !c.email.trim())}>
+							{inviteMutation.isPending && <Loader2 className="size-4 animate-spin" aria-hidden="true" />}
+							Отправить
+						</Button>
+					</div>
+				</form>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/src/components/procurement-status-donut.test.tsx
+++ b/src/components/procurement-status-donut.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ProcurementStatus } from "@/data/analytics-types";
+import { ProcurementStatusDonut } from "./procurement-status-donut";
+
+vi.mock("recharts", async () => {
+	const actual = await vi.importActual<typeof import("recharts")>("recharts");
+	return {
+		...actual,
+		ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+			<div data-testid="responsive-container" style={{ width: 320, height: 200 }}>
+				{children}
+			</div>
+		),
+	};
+});
+
+const mockStatusBreakdown: Record<ProcurementStatus, number> = {
+	awaiting_analytics: 5,
+	searching: 8,
+	negotiating: 3,
+	completed: 10,
+};
+
+describe("ProcurementStatusDonut", () => {
+	it("renders all status labels in the legend", () => {
+		render(<ProcurementStatusDonut statusBreakdown={mockStatusBreakdown} />);
+		expect(screen.getByText("Ожидание аналитики")).toBeInTheDocument();
+		expect(screen.getByText("Ищем поставщиков")).toBeInTheDocument();
+		expect(screen.getByText("Ведём переговоры")).toBeInTheDocument();
+		expect(screen.getByText("Переговоры завершены")).toBeInTheDocument();
+	});
+
+	it("renders item counts for each status in the legend", () => {
+		render(<ProcurementStatusDonut statusBreakdown={mockStatusBreakdown} />);
+		const legend = screen.getByTestId("status-donut-legend");
+		expect(legend).toHaveTextContent("5");
+		expect(legend).toHaveTextContent("8");
+		expect(legend).toHaveTextContent("3");
+		expect(legend).toHaveTextContent("10");
+	});
+
+	it("renders section heading", () => {
+		render(<ProcurementStatusDonut statusBreakdown={mockStatusBreakdown} />);
+		expect(screen.getByText("Статусы позиций")).toBeInTheDocument();
+	});
+});

--- a/src/components/procurement-status-donut.tsx
+++ b/src/components/procurement-status-donut.tsx
@@ -1,0 +1,66 @@
+import { Pie, PieChart } from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import type { ProcurementStatus } from "@/data/analytics-types";
+import { STATUS_LABELS } from "@/data/types";
+
+const PROCUREMENT_STATUSES: ProcurementStatus[] = ["awaiting_analytics", "searching", "negotiating", "completed"];
+
+const STATUS_COLORS: Record<ProcurementStatus, string> = {
+	awaiting_analytics: "oklch(0.70 0.15 60)",
+	searching: "oklch(0.65 0.18 250)",
+	negotiating: "oklch(0.62 0.20 295)",
+	completed: "oklch(0.60 0.20 145)",
+};
+
+const chartConfig: ChartConfig = Object.fromEntries(
+	PROCUREMENT_STATUSES.map((status) => [status, { label: STATUS_LABELS[status], color: STATUS_COLORS[status] }]),
+);
+
+interface Props {
+	statusBreakdown: Record<ProcurementStatus, number>;
+}
+
+export function ProcurementStatusDonut({ statusBreakdown }: Props) {
+	const data = PROCUREMENT_STATUSES.map((status) => ({
+		status,
+		label: STATUS_LABELS[status],
+		count: statusBreakdown[status],
+		fill: STATUS_COLORS[status],
+	}));
+
+	const total = data.reduce((sum, d) => sum + d.count, 0);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Статусы позиций</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<div className="flex flex-col items-center gap-6 sm:flex-row">
+					<div className="relative shrink-0">
+						<ChartContainer config={chartConfig} className="h-[200px] w-[200px]">
+							<PieChart>
+								<ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+								<Pie data={data} dataKey="count" nameKey="status" innerRadius={60} strokeWidth={2} />
+							</PieChart>
+						</ChartContainer>
+						<div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+							<span className="tabular-nums text-3xl font-bold">{total}</span>
+							<span className="text-xs text-muted-foreground">Позиций</span>
+						</div>
+					</div>
+					<div data-testid="status-donut-legend" className="flex flex-1 flex-col gap-3">
+						{data.map((item) => (
+							<div key={item.status} className="flex items-center gap-3 text-sm">
+								<div className="size-3 shrink-0 rounded-full" style={{ backgroundColor: item.fill }} />
+								<span className="flex-1 text-muted-foreground">{item.label}</span>
+								<span className="tabular-nums font-semibold">{item.count}</span>
+							</div>
+						))}
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/components/settings-sidebar.test.tsx
+++ b/src/components/settings-sidebar.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as auth from "@/data/auth";
+import { SettingsSidebar } from "./settings-sidebar";
+
+function renderSidebar(path = "/settings/profile", open = true) {
+	return render(
+		<MemoryRouter initialEntries={[path]}>
+			<SettingsSidebar open={open} onOpenChange={vi.fn()} />
+		</MemoryRouter>,
+	);
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("SettingsSidebar", () => {
+	test("renders section headers", () => {
+		renderSidebar();
+		expect(screen.getByText("Пользователь")).toBeInTheDocument();
+		expect(screen.getByText("Рабочее пространство")).toBeInTheDocument();
+	});
+
+	test("renders nav items Профиль, Компании, Сотрудники", () => {
+		renderSidebar();
+		expect(screen.getByRole("link", { name: "Профиль" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Компании" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Сотрудники" })).toBeInTheDocument();
+	});
+
+	test("highlights active Профиль when on /settings/profile", () => {
+		renderSidebar("/settings/profile");
+		const link = screen.getByRole("link", { name: "Профиль" });
+		expect(link).toHaveAttribute("aria-current", "page");
+	});
+
+	test("highlights active Компании when on /settings/companies", () => {
+		renderSidebar("/settings/companies");
+		const link = screen.getByRole("link", { name: "Компании" });
+		expect(link).toHaveAttribute("aria-current", "page");
+	});
+
+	test("logout button calls clearTokens", async () => {
+		const clearTokensSpy = vi.spyOn(auth, "clearTokens").mockImplementation(() => {});
+		renderSidebar();
+		const user = userEvent.setup();
+		await user.click(screen.getByRole("button", { name: "Выйти" }));
+		expect(clearTokensSpy).toHaveBeenCalledOnce();
+	});
+
+	test("when closed renders only open toggle button", () => {
+		renderSidebar("/settings/profile", false);
+		expect(screen.queryByRole("link", { name: "Профиль" })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Открыть настройки" })).toBeInTheDocument();
+	});
+
+	test("calls onOpenChange when close button clicked", async () => {
+		const onOpenChange = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<MemoryRouter initialEntries={["/settings/profile"]}>
+				<SettingsSidebar open onOpenChange={onOpenChange} />
+			</MemoryRouter>,
+		);
+		await user.click(screen.getByRole("button", { name: "Закрыть настройки" }));
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+});

--- a/src/components/settings-sidebar.tsx
+++ b/src/components/settings-sidebar.tsx
@@ -1,0 +1,95 @@
+import { Building2, ChevronLeft, LogOut, PanelLeft, User, Users } from "lucide-react";
+import { Link, useLocation } from "react-router";
+import { Button } from "@/components/ui/button";
+import { clearTokens } from "@/data/auth";
+import { cn } from "@/lib/utils";
+
+interface SettingsSidebarProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+const NAV_ITEMS = [
+	{
+		section: "Пользователь",
+		items: [{ path: "/settings/profile", label: "Профиль", icon: User }],
+	},
+	{
+		section: "Рабочее пространство",
+		items: [
+			{ path: "/settings/companies", label: "Компании", icon: Building2 },
+			{ path: "/settings/employees", label: "Сотрудники", icon: Users },
+		],
+	},
+];
+
+function NavLink({ path, label, icon: Icon }: { path: string; label: string; icon: React.ElementType }) {
+	const { pathname } = useLocation();
+	const active = pathname === path;
+
+	return (
+		<Link
+			to={path}
+			aria-current={active ? "page" : undefined}
+			className={cn(
+				"flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
+				active
+					? "bg-sidebar-accent font-medium text-sidebar-accent-foreground"
+					: "text-sidebar-foreground hover:bg-sidebar-accent/50",
+			)}
+		>
+			<Icon className="size-4 shrink-0" aria-hidden="true" />
+			{label}
+		</Link>
+	);
+}
+
+export function SettingsSidebar({ open, onOpenChange }: SettingsSidebarProps) {
+	if (!open) {
+		return (
+			<div className="hidden shrink-0 flex-col items-center border-r border-sidebar-border bg-sidebar p-2 md:flex">
+				<Button variant="ghost" size="icon-sm" onClick={() => onOpenChange(true)} aria-label="Открыть настройки">
+					<PanelLeft className="size-4" />
+				</Button>
+			</div>
+		);
+	}
+
+	const sidebarContent = (
+		<aside className="flex h-full w-full flex-col bg-sidebar text-sidebar-foreground" data-testid="settings-sidebar">
+			<div className="flex shrink-0 items-center justify-between border-b border-sidebar-border px-3 py-2">
+				<h2 className="text-sm font-semibold">Настройки</h2>
+				<Button variant="ghost" size="icon-sm" onClick={() => onOpenChange(false)} aria-label="Закрыть настройки">
+					<ChevronLeft className="size-4" />
+				</Button>
+			</div>
+
+			<nav className="flex-1 overflow-y-auto p-2" aria-label="Настройки">
+				{NAV_ITEMS.map(({ section, items }) => (
+					<div key={section} className="mb-4">
+						<p className="mb-1 px-2 text-xs font-medium text-muted-foreground">{section}</p>
+						<div className="space-y-0.5">
+							{items.map((item) => (
+								<NavLink key={item.path} {...item} />
+							))}
+						</div>
+					</div>
+				))}
+			</nav>
+
+			<div className="shrink-0 border-t border-sidebar-border p-2">
+				<button
+					type="button"
+					onClick={clearTokens}
+					aria-label="Выйти"
+					className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-destructive transition-colors hover:bg-destructive/10"
+				>
+					<LogOut className="size-4 shrink-0" aria-hidden="true" />
+					Выйти
+				</button>
+			</div>
+		</aside>
+	);
+
+	return <div className="w-52 shrink-0 border-r border-sidebar-border">{sidebarContent}</div>;
+}

--- a/src/components/supplier-pipeline-chart.test.tsx
+++ b/src/components/supplier-pipeline-chart.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { SupplierStatus } from "@/data/supplier-types";
+import { SUPPLIER_STATUS_LABELS } from "@/data/supplier-types";
+import { SupplierPipelineChart } from "./supplier-pipeline-chart";
+
+const mockPipeline: Record<SupplierStatus, number> = {
+	письмо_не_отправлено: 10,
+	ждем_ответа: 5,
+	переговоры: 3,
+	получено_кп: 7,
+	отказ: 2,
+};
+
+describe("SupplierPipelineChart", () => {
+	it("renders the heading", () => {
+		render(<SupplierPipelineChart supplierPipeline={mockPipeline} />);
+		expect(screen.getByText("Статусы поставщиков")).toBeInTheDocument();
+	});
+
+	it("renders all supplier status labels in the legend", () => {
+		render(<SupplierPipelineChart supplierPipeline={mockPipeline} />);
+		const legend = screen.getByTestId("supplier-pipeline-legend");
+		for (const label of Object.values(SUPPLIER_STATUS_LABELS)) {
+			expect(within(legend).getByText(label)).toBeInTheDocument();
+		}
+	});
+
+	it("renders supplier counts in the legend", () => {
+		render(<SupplierPipelineChart supplierPipeline={mockPipeline} />);
+		const legend = screen.getByTestId("supplier-pipeline-legend");
+		expect(within(legend).getByText("10")).toBeInTheDocument();
+		expect(within(legend).getByText("5")).toBeInTheDocument();
+		expect(within(legend).getByText("3")).toBeInTheDocument();
+		expect(within(legend).getByText("7")).toBeInTheDocument();
+		expect(within(legend).getByText("2")).toBeInTheDocument();
+	});
+});

--- a/src/components/supplier-pipeline-chart.tsx
+++ b/src/components/supplier-pipeline-chart.tsx
@@ -1,0 +1,58 @@
+import { Bar, BarChart, Cell, LabelList, XAxis, YAxis } from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import {
+	SUPPLIER_STATUS_CHART_COLORS,
+	SUPPLIER_STATUS_LABELS,
+	SUPPLIER_STATUSES,
+	type SupplierStatus,
+} from "@/data/supplier-types";
+
+const chartConfig: ChartConfig = Object.fromEntries(
+	SUPPLIER_STATUSES.map((s) => [s, { label: SUPPLIER_STATUS_LABELS[s], color: SUPPLIER_STATUS_CHART_COLORS[s] }]),
+);
+
+interface Props {
+	supplierPipeline: Record<SupplierStatus, number>;
+}
+
+export function SupplierPipelineChart({ supplierPipeline }: Props) {
+	const chartData = SUPPLIER_STATUSES.map((status) => ({
+		status,
+		label: SUPPLIER_STATUS_LABELS[status],
+		count: supplierPipeline[status],
+		fill: SUPPLIER_STATUS_CHART_COLORS[status],
+	}));
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Статусы поставщиков</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<ChartContainer config={chartConfig} className="h-[260px] w-full">
+					<BarChart layout="vertical" data={chartData} margin={{ right: 48, left: 8 }}>
+						<YAxis dataKey="label" type="category" width={0} tick={false} axisLine={false} />
+						<XAxis type="number" hide />
+						<ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+						<Bar dataKey="count" radius={4}>
+							{chartData.map((entry) => (
+								<Cell key={entry.status} fill={entry.fill} />
+							))}
+							<LabelList dataKey="count" position="right" className="fill-muted-foreground text-xs" />
+						</Bar>
+					</BarChart>
+				</ChartContainer>
+				<div data-testid="supplier-pipeline-legend" className="mt-4 flex flex-col gap-2">
+					{chartData.map((item) => (
+						<div key={item.status} className="flex items-center gap-3 text-sm">
+							<div className="size-3 shrink-0 rounded-full" style={{ backgroundColor: item.fill }} />
+							<span className="flex-1">{item.label}</span>
+							<span className="tabular-nums font-semibold">{item.count}</span>
+						</div>
+					))}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,70 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({ className, size = "default", ...props }: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+	return (
+		<div
+			data-slot="card"
+			data-size={size}
+			className={cn(
+				"group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="card-header"
+			className={cn(
+				"group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="card-title"
+			className={cn("font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm", className)}
+			{...props}
+		/>
+	);
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+	return <div data-slot="card-description" className={cn("text-sm text-muted-foreground", className)} {...props} />;
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="card-action"
+			className={cn("col-start-2 row-span-2 row-start-1 self-start justify-self-end", className)}
+			{...props}
+		/>
+	);
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+	return <div data-slot="card-content" className={cn("px-4 group-data-[size=sm]/card:px-3", className)} {...props} />;
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="card-footer"
+			className={cn("flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3", className)}
+			{...props}
+		/>
+	);
+}
+
+export { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/src/components/user-avatar-menu.test.tsx
+++ b/src/components/user-avatar-menu.test.tsx
@@ -31,7 +31,18 @@ function renderMenu(initialEntries = ["/"]) {
 							<>
 								<UserAvatarMenu />
 								<Routes>
-									<Route path="/profile" element={<div data-testid="profile-page">Profile</div>} />
+									<Route
+										path="/settings/profile"
+										element={<div data-testid="settings-profile-page">Settings Profile</div>}
+									/>
+									<Route
+										path="/settings/companies"
+										element={<div data-testid="settings-companies-page">Settings Companies</div>}
+									/>
+									<Route
+										path="/settings/employees"
+										element={<div data-testid="settings-employees-page">Settings Employees</div>}
+									/>
 								</Routes>
 							</>
 						}
@@ -62,7 +73,7 @@ describe("UserAvatarMenu", () => {
 		expect(screen.queryByText("ИП")).not.toBeInTheDocument();
 	});
 
-	test("Мой профиль navigates to /profile", async () => {
+	test("Мой профиль navigates to /settings/profile", async () => {
 		server.use(http.get("/api/v1/auth/settings", () => HttpResponse.json(MOCK_SETTINGS)));
 
 		renderMenu();
@@ -77,11 +88,11 @@ describe("UserAvatarMenu", () => {
 		await user.click(screen.getByText("Мой профиль"));
 
 		await waitFor(() => {
-			expect(screen.getByTestId("profile-page")).toBeInTheDocument();
+			expect(screen.getByTestId("settings-profile-page")).toBeInTheDocument();
 		});
 	});
 
-	test("Настройки navigates to /profile?tab=settings", async () => {
+	test("Компании navigates to /settings/companies", async () => {
 		server.use(http.get("/api/v1/auth/settings", () => HttpResponse.json(MOCK_SETTINGS)));
 
 		renderMenu();
@@ -90,13 +101,13 @@ describe("UserAvatarMenu", () => {
 		await user.click(screen.getByRole("button", { name: "Меню пользователя" }));
 
 		await waitFor(() => {
-			expect(screen.getByText("Настройки")).toBeInTheDocument();
+			expect(screen.getByRole("menuitem", { name: "Компании" })).toBeInTheDocument();
 		});
 
-		await user.click(screen.getByText("Настройки"));
+		await user.click(screen.getByRole("menuitem", { name: "Компании" }));
 
 		await waitFor(() => {
-			expect(screen.getByTestId("profile-page")).toBeInTheDocument();
+			expect(screen.getByTestId("settings-companies-page")).toBeInTheDocument();
 		});
 	});
 });

--- a/src/components/user-avatar-menu.tsx
+++ b/src/components/user-avatar-menu.tsx
@@ -1,4 +1,4 @@
-import { CircleUser, LogOut, Moon, Settings, Sun, User } from "lucide-react";
+import { Building2, CircleUser, LogOut, Moon, Sun, User, Users } from "lucide-react";
 import { useNavigate } from "react-router";
 import {
 	DropdownMenu,
@@ -50,14 +50,19 @@ export function UserAvatarMenu({ side = "bottom", align = "end", iconClassName =
 				</button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent side={side} align={align} className="w-56">
-				<DropdownMenuItem onSelect={() => navigate("/profile")}>
+				<DropdownMenuItem onSelect={() => navigate("/settings/profile")}>
 					<User />
 					Мой профиль
 				</DropdownMenuItem>
-				<DropdownMenuItem onSelect={() => navigate("/profile?tab=settings")}>
-					<Settings />
-					Настройки
+				<DropdownMenuItem onSelect={() => navigate("/settings/companies")}>
+					<Building2 />
+					Компании
 				</DropdownMenuItem>
+				<DropdownMenuItem onSelect={() => navigate("/settings/employees")}>
+					<Users />
+					Сотрудники
+				</DropdownMenuItem>
+				<DropdownMenuSeparator />
 				<DropdownMenuItem
 					onSelect={() => {
 						const isDark = document.documentElement.classList.toggle("dark");

--- a/src/data/analytics-types.ts
+++ b/src/data/analytics-types.ts
@@ -8,6 +8,14 @@ export interface AnalyticsKpis {
 	openTasksCount: number;
 }
 
+export interface FolderBreakdown {
+	folderId: string;
+	folderName: string;
+	overpayment: number;
+	deviationPct: number;
+}
+
 export interface AnalyticsSummaryResponse {
 	kpis: AnalyticsKpis;
+	folderBreakdown?: FolderBreakdown[];
 }

--- a/src/data/analytics-types.ts
+++ b/src/data/analytics-types.ts
@@ -1,3 +1,7 @@
+import type { ProcurementStatus } from "./types";
+
+export type { ProcurementStatus };
+
 export interface AnalyticsKpis {
 	totalSpend: number;
 	totalOverpayment: number;
@@ -18,4 +22,5 @@ export interface FolderBreakdown {
 export interface AnalyticsSummaryResponse {
 	kpis: AnalyticsKpis;
 	folderBreakdown?: FolderBreakdown[];
+	statusBreakdown?: Record<ProcurementStatus, number>;
 }

--- a/src/data/analytics-types.ts
+++ b/src/data/analytics-types.ts
@@ -1,0 +1,13 @@
+export interface AnalyticsKpis {
+	totalSpend: number;
+	totalOverpayment: number;
+	totalSavings: number;
+	completedCount: number;
+	totalCount: number;
+	pendingAnalysisCount: number;
+	openTasksCount: number;
+}
+
+export interface AnalyticsSummaryResponse {
+	kpis: AnalyticsKpis;
+}

--- a/src/data/api-client.ts
+++ b/src/data/api-client.ts
@@ -1,3 +1,4 @@
+import type { AnalyticsSummaryResponse } from "./analytics-types";
 import { ApiError } from "./api-error";
 import { clearTokens, getAccessToken, getRefreshToken, setTokens } from "./auth";
 import { refreshToken } from "./auth-api";
@@ -21,6 +22,7 @@ import type {
 const BASE = "/api/v1/company";
 const COMPANIES_BASE = "/api/v1/companies";
 const TASKS_BASE = "/api/v1/company/tasks";
+const ANALYTICS_BASE = "/api/v1/analytics";
 
 const DECIMAL_FIELDS = new Set([
 	"currentPrice",
@@ -445,6 +447,14 @@ export async function updateEmployeePermissions(
 		method: "PATCH",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(data),
+	});
+}
+
+// --- Analytics ---
+
+export async function fetchAnalyticsSummary(params: { company?: string } = {}): Promise<AnalyticsSummaryResponse> {
+	return request(`/summary${buildQuery(params as Record<string, string | undefined>)}`, {
+		base: ANALYTICS_BASE,
 	});
 }
 

--- a/src/data/api-client.ts
+++ b/src/data/api-client.ts
@@ -2,6 +2,7 @@ import type { AnalyticsSummaryResponse } from "./analytics-types";
 import { ApiError } from "./api-error";
 import { clearTokens, getAccessToken, getRefreshToken, setTokens } from "./auth";
 import { refreshToken } from "./auth-api";
+import type { SupplierStatus } from "./supplier-types";
 import type { Attachment, Task, TaskStatus } from "./task-types";
 import { getTenant } from "./tenant";
 import type {
@@ -454,6 +455,14 @@ export async function updateEmployeePermissions(
 
 export async function fetchAnalyticsSummary(params: { company?: string } = {}): Promise<AnalyticsSummaryResponse> {
 	return request(`/summary${buildQuery(params as Record<string, string | undefined>)}`, {
+		base: ANALYTICS_BASE,
+	});
+}
+
+export async function fetchAnalyticsPipeline(
+	params: { company?: string } = {},
+): Promise<Record<SupplierStatus, number>> {
+	return request(`/supplier-pipeline${buildQuery(params as Record<string, string | undefined>)}`, {
 		base: ANALYTICS_BASE,
 	});
 }

--- a/src/data/settings-api.ts
+++ b/src/data/settings-api.ts
@@ -5,6 +5,7 @@ const BASE = "/api/v1/auth";
 export interface UserSettings {
 	first_name: string;
 	last_name: string;
+	patronymic?: string;
 	email: string;
 	phone: string;
 	avatar_icon: string;
@@ -12,7 +13,9 @@ export interface UserSettings {
 	mailing_allowed: boolean;
 }
 
-export type SettingsPatch = Partial<Pick<UserSettings, "first_name" | "last_name" | "phone" | "mailing_allowed">>;
+export type SettingsPatch = Partial<
+	Pick<UserSettings, "first_name" | "last_name" | "patronymic" | "phone" | "mailing_allowed">
+>;
 
 export async function fetchSettings(): Promise<UserSettings> {
 	return request("/settings", { base: BASE });

--- a/src/data/supplier-types.ts
+++ b/src/data/supplier-types.ts
@@ -16,6 +16,14 @@ export const SUPPLIER_STATUS_LABELS: Record<SupplierStatus, string> = {
 	отказ: "Отказ",
 };
 
+export const SUPPLIER_STATUS_CHART_COLORS: Record<SupplierStatus, string> = {
+	письмо_не_отправлено: "oklch(0.70 0.10 250)",
+	ждем_ответа: "oklch(0.60 0.22 295)",
+	переговоры: "oklch(0.62 0.20 250)",
+	получено_кп: "oklch(0.60 0.20 145)",
+	отказ: "oklch(0.65 0.22 25)",
+};
+
 export const SUPPLIER_STATUS_CONFIG: Record<SupplierStatus, { label: string; className: string }> = {
 	письмо_не_отправлено: { label: SUPPLIER_STATUS_LABELS.письмо_не_отправлено, className: "text-muted-foreground" },
 	ждем_ответа: { label: SUPPLIER_STATUS_LABELS.ждем_ответа, className: "text-violet-600 dark:text-violet-400" },

--- a/src/data/use-analytics.test.ts
+++ b/src/data/use-analytics.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { server } from "@/test-msw";
 import { createQueryWrapper, createTestQueryClient, mockHostname } from "@/test-utils";
 import type { AnalyticsKpis, FolderBreakdown, ProcurementStatus } from "./analytics-types";
+import type { SupplierStatus } from "./supplier-types";
 import { useAnalyticsSummary } from "./use-analytics";
 
 const mockKpis: AnalyticsKpis = {
@@ -16,10 +17,20 @@ const mockKpis: AnalyticsKpis = {
 	openTasksCount: 3,
 };
 
+const DEFAULT_PIPELINE: Record<SupplierStatus, number> = {
+	письмо_не_отправлено: 0,
+	ждем_ответа: 0,
+	переговоры: 0,
+	получено_кп: 0,
+	отказ: 0,
+};
+
 beforeEach(() => {
 	mockHostname("acme.localhost");
 	localStorage.setItem("auth-access-token", "test-token");
 	localStorage.setItem("auth-refresh-token", "test-refresh");
+	// default pipeline handler so existing tests don't see an unhandled-request error
+	server.use(http.get("/api/v1/analytics/supplier-pipeline", () => HttpResponse.json(DEFAULT_PIPELINE)));
 });
 
 afterEach(() => {
@@ -161,5 +172,48 @@ describe("useAnalyticsSummary", () => {
 
 		await waitFor(() => expect(result.current.isLoading).toBe(false));
 		expect(capturedUrl).toContain("company=co-123");
+	});
+
+	it("exposes supplierPipeline from pipeline endpoint", async () => {
+		const pipeline: Record<SupplierStatus, number> = {
+			письмо_не_отправлено: 8,
+			ждем_ответа: 4,
+			переговоры: 2,
+			получено_кп: 6,
+			отказ: 1,
+		};
+		server.use(
+			http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis: mockKpis })),
+			http.get("/api/v1/analytics/supplier-pipeline", () => HttpResponse.json(pipeline)),
+		);
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.supplierPipeline).toEqual(pipeline);
+	});
+
+	it("returns default supplierPipeline (all zeros) when pipeline endpoint returns empty", async () => {
+		server.use(
+			http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis: mockKpis })),
+			http.get("/api/v1/analytics/supplier-pipeline", () => HttpResponse.json(DEFAULT_PIPELINE)),
+		);
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.supplierPipeline).toEqual({
+			письмо_не_отправлено: 0,
+			ждем_ответа: 0,
+			переговоры: 0,
+			получено_кп: 0,
+			отказ: 0,
+		});
 	});
 });

--- a/src/data/use-analytics.test.ts
+++ b/src/data/use-analytics.test.ts
@@ -3,7 +3,7 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { server } from "@/test-msw";
 import { createQueryWrapper, createTestQueryClient, mockHostname } from "@/test-utils";
-import type { AnalyticsKpis } from "./analytics-types";
+import type { AnalyticsKpis, FolderBreakdown } from "./analytics-types";
 import { useAnalyticsSummary } from "./use-analytics";
 
 const mockKpis: AnalyticsKpis = {
@@ -80,6 +80,34 @@ describe("useAnalyticsSummary", () => {
 
 		await waitFor(() => expect(result.current.isLoading).toBe(false));
 		expect(result.current.kpis?.pendingAnalysisCount).toBe(5);
+	});
+
+	it("exposes folderBreakdown from response", async () => {
+		const folderBreakdown: FolderBreakdown[] = [
+			{ folderId: "f1", folderName: "Электроника", overpayment: 100_000, deviationPct: 15 },
+			{ folderId: "f2", folderName: "Мебель", overpayment: 50_000, deviationPct: 8 },
+		];
+		server.use(http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis: mockKpis, folderBreakdown })));
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.folderBreakdown).toEqual(folderBreakdown);
+	});
+
+	it("returns empty folderBreakdown when not present in response", async () => {
+		server.use(http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis: mockKpis })));
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.folderBreakdown).toEqual([]);
 	});
 
 	it("passes company param to API request", async () => {

--- a/src/data/use-analytics.test.ts
+++ b/src/data/use-analytics.test.ts
@@ -2,7 +2,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { server } from "@/test-msw";
-import { createQueryWrapper, createTestQueryClient, mockHostname } from "@/test-utils";
+import { createQueryWrapper, createTestQueryClient, makeTask, mockHostname } from "@/test-utils";
 import type { AnalyticsKpis, FolderBreakdown, ProcurementStatus } from "./analytics-types";
 import type { SupplierStatus } from "./supplier-types";
 import { useAnalyticsSummary } from "./use-analytics";
@@ -31,6 +31,10 @@ beforeEach(() => {
 	localStorage.setItem("auth-refresh-token", "test-refresh");
 	// default pipeline handler so existing tests don't see an unhandled-request error
 	server.use(http.get("/api/v1/analytics/supplier-pipeline", () => HttpResponse.json(DEFAULT_PIPELINE)));
+	// default tasks handler so existing tests don't see an unhandled-request error
+	server.use(
+		http.get("/api/v1/company/tasks/", () => HttpResponse.json({ count: 0, results: [], next: null, previous: null })),
+	);
 });
 
 afterEach(() => {
@@ -215,5 +219,44 @@ describe("useAnalyticsSummary", () => {
 			получено_кп: 0,
 			отказ: 0,
 		});
+	});
+
+	it("derives tasksSummary open and overdue counts from tasks endpoint", async () => {
+		const pastDate = "2026-01-01T00:00:00.000Z";
+		const futureDate = "2026-12-31T00:00:00.000Z";
+		const tasks = [
+			makeTask("t1", { status: "assigned", deadlineAt: pastDate }),
+			makeTask("t2", { status: "in_progress", deadlineAt: pastDate }),
+			makeTask("t3", { status: "assigned", deadlineAt: futureDate }),
+			makeTask("t4", { status: "completed", deadlineAt: pastDate }),
+			makeTask("t5", { status: "archived", deadlineAt: pastDate }),
+		];
+		server.use(
+			http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis: mockKpis })),
+			http.get("/api/v1/company/tasks/", () =>
+				HttpResponse.json({ count: tasks.length, results: tasks, next: null, previous: null }),
+			),
+		);
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.tasksSummary.open).toBe(3);
+		expect(result.current.tasksSummary.overdue).toBe(2);
+	});
+
+	it("returns default tasksSummary (all zeros) when tasks endpoint returns empty", async () => {
+		server.use(http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis: mockKpis })));
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.tasksSummary).toEqual({ open: 0, overdue: 0 });
 	});
 });

--- a/src/data/use-analytics.test.ts
+++ b/src/data/use-analytics.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { server } from "@/test-msw";
+import { createQueryWrapper, createTestQueryClient, mockHostname } from "@/test-utils";
+import type { AnalyticsKpis } from "./analytics-types";
+import { useAnalyticsSummary } from "./use-analytics";
+
+const mockKpis: AnalyticsKpis = {
+	totalSpend: 5_000_000,
+	totalOverpayment: 300_000,
+	totalSavings: 150_000,
+	completedCount: 8,
+	totalCount: 20,
+	pendingAnalysisCount: 4,
+	openTasksCount: 3,
+};
+
+beforeEach(() => {
+	mockHostname("acme.localhost");
+	localStorage.setItem("auth-access-token", "test-token");
+	localStorage.setItem("auth-refresh-token", "test-refresh");
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+describe("useAnalyticsSummary", () => {
+	it("returns kpis shape on success", async () => {
+		server.use(http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis: mockKpis })));
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.kpis).toEqual(mockKpis);
+		expect(result.current.isError).toBe(false);
+	});
+
+	it("returns isLoading true and kpis null initially", () => {
+		server.use(
+			http.get("/api/v1/analytics/summary", async () => {
+				await new Promise((r) => setTimeout(r, 100));
+				return HttpResponse.json({ kpis: mockKpis });
+			}),
+		);
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		expect(result.current.isLoading).toBe(true);
+		expect(result.current.kpis).toBeNull();
+	});
+
+	it("returns isError true on failure", async () => {
+		server.use(http.get("/api/v1/analytics/summary", () => HttpResponse.json({}, { status: 500 })));
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect(result.current.kpis).toBeNull();
+	});
+
+	it("exposes pendingAnalysisCount from kpis", async () => {
+		const kpis = { ...mockKpis, pendingAnalysisCount: 5 };
+		server.use(http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis })));
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.kpis?.pendingAnalysisCount).toBe(5);
+	});
+
+	it("passes company param to API request", async () => {
+		let capturedUrl = "";
+		server.use(
+			http.get("/api/v1/analytics/summary", ({ request }) => {
+				capturedUrl = request.url;
+				return HttpResponse.json({ kpis: mockKpis });
+			}),
+		);
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary({ company: "co-123" }), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(capturedUrl).toContain("company=co-123");
+	});
+});

--- a/src/data/use-analytics.test.ts
+++ b/src/data/use-analytics.test.ts
@@ -3,7 +3,7 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { server } from "@/test-msw";
 import { createQueryWrapper, createTestQueryClient, mockHostname } from "@/test-utils";
-import type { AnalyticsKpis, FolderBreakdown } from "./analytics-types";
+import type { AnalyticsKpis, FolderBreakdown, ProcurementStatus } from "./analytics-types";
 import { useAnalyticsSummary } from "./use-analytics";
 
 const mockKpis: AnalyticsKpis = {
@@ -108,6 +108,41 @@ describe("useAnalyticsSummary", () => {
 
 		await waitFor(() => expect(result.current.isLoading).toBe(false));
 		expect(result.current.folderBreakdown).toEqual([]);
+	});
+
+	it("exposes statusBreakdown from response", async () => {
+		const statusBreakdown: Record<ProcurementStatus, number> = {
+			awaiting_analytics: 3,
+			searching: 7,
+			negotiating: 2,
+			completed: 12,
+		};
+		server.use(http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis: mockKpis, statusBreakdown })));
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.statusBreakdown).toEqual(statusBreakdown);
+	});
+
+	it("returns default statusBreakdown (all zeros) when absent from response", async () => {
+		server.use(http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis: mockKpis })));
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderHook(() => useAnalyticsSummary(), {
+			wrapper: createQueryWrapper(queryClient),
+		});
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.statusBreakdown).toEqual({
+			awaiting_analytics: 0,
+			searching: 0,
+			negotiating: 0,
+			completed: 0,
+		});
 	});
 
 	it("passes company param to API request", async () => {

--- a/src/data/use-analytics.ts
+++ b/src/data/use-analytics.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import type { AnalyticsKpis, FolderBreakdown, ProcurementStatus } from "./analytics-types";
-import { fetchAnalyticsPipeline, fetchAnalyticsSummary } from "./api-client";
+import { fetchAnalyticsPipeline, fetchAnalyticsSummary, fetchTasks } from "./api-client";
 import type { SupplierStatus } from "./supplier-types";
 import { SUPPLIER_STATUSES } from "./supplier-types";
 
@@ -27,12 +27,26 @@ export function useAnalyticsSummary({ company }: { company?: string } = {}) {
 		queryFn: () => fetchAnalyticsPipeline({ company }),
 	});
 
+	const tasksQuery = useQuery({
+		queryKey: ["analytics-tasks", { company }],
+		queryFn: () => fetchTasks({ company, page_size: 200 }),
+	});
+
+	const activeTasks = (tasksQuery.data?.results ?? []).filter(
+		(t) => t.status === "assigned" || t.status === "in_progress",
+	);
+	const tasksSummary = {
+		open: activeTasks.length,
+		overdue: activeTasks.filter((t) => t.deadlineAt < new Date().toISOString()).length,
+	};
+
 	return {
 		kpis: (query.data?.kpis ?? null) as AnalyticsKpis | null,
 		folderBreakdown: (query.data?.folderBreakdown ?? []) as FolderBreakdown[],
 		statusBreakdown: query.data?.statusBreakdown ?? DEFAULT_STATUS_BREAKDOWN,
 		supplierPipeline: pipelineQuery.data ?? DEFAULT_SUPPLIER_PIPELINE,
-		isLoading: query.isLoading || pipelineQuery.isLoading,
-		isError: query.isError || pipelineQuery.isError,
+		tasksSummary,
+		isLoading: query.isLoading || pipelineQuery.isLoading || tasksQuery.isLoading,
+		isError: query.isError || pipelineQuery.isError || tasksQuery.isError,
 	};
 }

--- a/src/data/use-analytics.ts
+++ b/src/data/use-analytics.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import type { AnalyticsKpis } from "./analytics-types";
+import { fetchAnalyticsSummary } from "./api-client";
+
+export function useAnalyticsSummary({ company }: { company?: string } = {}) {
+	const query = useQuery({
+		queryKey: ["analytics-summary", { company }],
+		queryFn: () => fetchAnalyticsSummary({ company }),
+	});
+
+	return {
+		kpis: (query.data?.kpis ?? null) as AnalyticsKpis | null,
+		isLoading: query.isLoading,
+		isError: query.isError,
+	};
+}

--- a/src/data/use-analytics.ts
+++ b/src/data/use-analytics.ts
@@ -1,6 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import type { AnalyticsKpis, FolderBreakdown } from "./analytics-types";
+import type { AnalyticsKpis, FolderBreakdown, ProcurementStatus } from "./analytics-types";
 import { fetchAnalyticsSummary } from "./api-client";
+
+const DEFAULT_STATUS_BREAKDOWN: Record<ProcurementStatus, number> = {
+	awaiting_analytics: 0,
+	searching: 0,
+	negotiating: 0,
+	completed: 0,
+};
 
 export function useAnalyticsSummary({ company }: { company?: string } = {}) {
 	const query = useQuery({
@@ -11,6 +18,7 @@ export function useAnalyticsSummary({ company }: { company?: string } = {}) {
 	return {
 		kpis: (query.data?.kpis ?? null) as AnalyticsKpis | null,
 		folderBreakdown: (query.data?.folderBreakdown ?? []) as FolderBreakdown[],
+		statusBreakdown: query.data?.statusBreakdown ?? DEFAULT_STATUS_BREAKDOWN,
 		isLoading: query.isLoading,
 		isError: query.isError,
 	};

--- a/src/data/use-analytics.ts
+++ b/src/data/use-analytics.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import type { AnalyticsKpis } from "./analytics-types";
+import type { AnalyticsKpis, FolderBreakdown } from "./analytics-types";
 import { fetchAnalyticsSummary } from "./api-client";
 
 export function useAnalyticsSummary({ company }: { company?: string } = {}) {
@@ -10,6 +10,7 @@ export function useAnalyticsSummary({ company }: { company?: string } = {}) {
 
 	return {
 		kpis: (query.data?.kpis ?? null) as AnalyticsKpis | null,
+		folderBreakdown: (query.data?.folderBreakdown ?? []) as FolderBreakdown[],
 		isLoading: query.isLoading,
 		isError: query.isError,
 	};

--- a/src/data/use-analytics.ts
+++ b/src/data/use-analytics.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import type { AnalyticsKpis, FolderBreakdown, ProcurementStatus } from "./analytics-types";
 import { fetchAnalyticsPipeline, fetchAnalyticsSummary, fetchTasks } from "./api-client";
 import type { SupplierStatus } from "./supplier-types";
@@ -27,17 +27,24 @@ export function useAnalyticsSummary({ company }: { company?: string } = {}) {
 		queryFn: () => fetchAnalyticsPipeline({ company }),
 	});
 
-	const tasksQuery = useQuery({
+	const tasksQuery = useInfiniteQuery({
 		queryKey: ["analytics-tasks", { company }],
-		queryFn: () => fetchTasks({ company, page_size: 200 }),
+		queryFn: ({ pageParam }) => fetchTasks({ company, page_size: 100, page: pageParam }),
+		initialPageParam: 1 as number,
+		getNextPageParam: (lastPage, _pages, lastPageParam) => (lastPage.next !== null ? lastPageParam + 1 : undefined),
 	});
 
-	const activeTasks = (tasksQuery.data?.results ?? []).filter(
-		(t) => t.status === "assigned" || t.status === "in_progress",
-	);
+	// Auto-fetch all pages to get complete task counts
+	if (tasksQuery.hasNextPage && !tasksQuery.isFetchingNextPage) {
+		tasksQuery.fetchNextPage();
+	}
+
+	const allTasks = tasksQuery.data?.pages.flatMap((p) => p.results) ?? [];
+	const activeTasks = allTasks.filter((t) => t.status === "assigned" || t.status === "in_progress");
+	const now = new Date();
 	const tasksSummary = {
 		open: activeTasks.length,
-		overdue: activeTasks.filter((t) => t.deadlineAt < new Date().toISOString()).length,
+		overdue: activeTasks.filter((t) => new Date(t.deadlineAt) < now).length,
 	};
 
 	return {

--- a/src/data/use-analytics.ts
+++ b/src/data/use-analytics.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import type { AnalyticsKpis, FolderBreakdown, ProcurementStatus } from "./analytics-types";
-import { fetchAnalyticsSummary } from "./api-client";
+import { fetchAnalyticsPipeline, fetchAnalyticsSummary } from "./api-client";
+import type { SupplierStatus } from "./supplier-types";
+import { SUPPLIER_STATUSES } from "./supplier-types";
 
 const DEFAULT_STATUS_BREAKDOWN: Record<ProcurementStatus, number> = {
 	awaiting_analytics: 0,
@@ -9,17 +11,28 @@ const DEFAULT_STATUS_BREAKDOWN: Record<ProcurementStatus, number> = {
 	completed: 0,
 };
 
+const DEFAULT_SUPPLIER_PIPELINE = Object.fromEntries(SUPPLIER_STATUSES.map((s) => [s, 0])) as Record<
+	SupplierStatus,
+	number
+>;
+
 export function useAnalyticsSummary({ company }: { company?: string } = {}) {
 	const query = useQuery({
 		queryKey: ["analytics-summary", { company }],
 		queryFn: () => fetchAnalyticsSummary({ company }),
 	});
 
+	const pipelineQuery = useQuery({
+		queryKey: ["analytics-supplier-pipeline", { company }],
+		queryFn: () => fetchAnalyticsPipeline({ company }),
+	});
+
 	return {
 		kpis: (query.data?.kpis ?? null) as AnalyticsKpis | null,
 		folderBreakdown: (query.data?.folderBreakdown ?? []) as FolderBreakdown[],
 		statusBreakdown: query.data?.statusBreakdown ?? DEFAULT_STATUS_BREAKDOWN,
-		isLoading: query.isLoading,
-		isError: query.isError,
+		supplierPipeline: pipelineQuery.data ?? DEFAULT_SUPPLIER_PIPELINE,
+		isLoading: query.isLoading || pipelineQuery.isLoading,
+		isError: query.isError || pipelineQuery.isError,
 	};
 }

--- a/src/data/use-workspace.ts
+++ b/src/data/use-workspace.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { EmployeePermissions } from "./types";
+import { fetchWorkspaceEmployees, inviteEmployees, updateWorkspaceEmployeePermissions } from "./workspace-api";
+import type { InvitePayload } from "./workspace-types";
+
+export function useWorkspaceEmployees() {
+	return useQuery({
+		queryKey: ["workspace-employees"],
+		queryFn: fetchWorkspaceEmployees,
+	});
+}
+
+export function useInviteEmployees() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (invites: InvitePayload[]) => inviteEmployees(invites),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["workspace-employees"] });
+		},
+	});
+}
+
+export function useUpdateWorkspaceEmployeePermissions(employeeId: number) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (data: Partial<Pick<EmployeePermissions, "analytics" | "procurement" | "companies" | "tasks">>) =>
+			updateWorkspaceEmployeePermissions(employeeId, data),
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: ["workspace-employees"] });
+		},
+	});
+}

--- a/src/data/workspace-api.ts
+++ b/src/data/workspace-api.ts
@@ -1,0 +1,30 @@
+import { request } from "./api-client";
+import type { EmployeePermissions } from "./types";
+import type { InvitePayload, WorkspaceEmployee } from "./workspace-types";
+
+const WORKSPACE_BASE = "/api/v1/workspace";
+
+export async function fetchWorkspaceEmployees(): Promise<{ employees: WorkspaceEmployee[] }> {
+	return request("/employees/", { base: WORKSPACE_BASE });
+}
+
+export async function inviteEmployees(invites: InvitePayload[]): Promise<void> {
+	return request("/employees/invite/", {
+		base: WORKSPACE_BASE,
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ invites }),
+	});
+}
+
+export async function updateWorkspaceEmployeePermissions(
+	employeeId: number,
+	data: Partial<Pick<EmployeePermissions, "analytics" | "procurement" | "companies" | "tasks">>,
+): Promise<EmployeePermissions> {
+	return request(`/employees/${employeeId}/permissions/`, {
+		base: WORKSPACE_BASE,
+		method: "PATCH",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(data),
+	});
+}

--- a/src/data/workspace-types.ts
+++ b/src/data/workspace-types.ts
@@ -1,0 +1,22 @@
+import type { EmployeePermissions, EmployeeRole } from "./types";
+
+export interface WorkspaceEmployee {
+	id: number;
+	firstName: string;
+	lastName: string;
+	patronymic: string;
+	position: string;
+	role: EmployeeRole;
+	phone: string;
+	email: string;
+	companies: Array<{ id: string; name: string }>;
+	registeredAt: string | null;
+	permissions: EmployeePermissions;
+}
+
+export interface InvitePayload {
+	email: string;
+	position: string;
+	role: EmployeeRole;
+	companies: string[];
+}

--- a/src/lib/breakpoints.ts
+++ b/src/lib/breakpoints.ts
@@ -1,0 +1,1 @@
+export const DESKTOP_QUERY = "(min-width: 1024px)";

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -95,6 +95,10 @@ export function formatAssigneeName(assignee: { firstName: string; lastName: stri
 	return `${assignee.lastName} ${assignee.firstName}`;
 }
 
+export function formatEmployeeFullName(emp: { firstName: string; lastName: string; patronymic?: string }): string {
+	return [emp.lastName, emp.firstName, emp.patronymic].filter(Boolean).join(" ");
+}
+
 export function pluralizeRu(count: number, one: string, few: string, many: string): string {
 	const mod100 = count % 100;
 	const mod10 = count % 10;

--- a/src/pages/analytics-page.test.tsx
+++ b/src/pages/analytics-page.test.tsx
@@ -30,6 +30,15 @@ beforeEach(() => {
 	// Default: single company, success analytics response
 	server.use(
 		http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis: mockKpis })),
+		http.get("/api/v1/analytics/supplier-pipeline", () =>
+			HttpResponse.json({
+				письмо_не_отправлено: 0,
+				ждем_ответа: 0,
+				переговоры: 0,
+				получено_кп: 0,
+				отказ: 0,
+			}),
+		),
 		http.get("/api/v1/companies/", () => HttpResponse.json({ companies: [makeCompany("co-1")], nextCursor: null })),
 	);
 });

--- a/src/pages/analytics-page.test.tsx
+++ b/src/pages/analytics-page.test.tsx
@@ -1,0 +1,130 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AnalyticsKpis } from "@/data/analytics-types";
+import { server } from "@/test-msw";
+import { createTestQueryClient, makeCompany, mockHostname } from "@/test-utils";
+import { AnalyticsPage } from "./analytics-page";
+
+const mockKpis: AnalyticsKpis = {
+	totalSpend: 5_000_000,
+	totalOverpayment: 300_000,
+	totalSavings: 150_000,
+	completedCount: 8,
+	totalCount: 20,
+	pendingAnalysisCount: 2,
+	openTasksCount: 5,
+};
+
+let queryClient: QueryClient;
+
+beforeEach(() => {
+	queryClient = createTestQueryClient();
+	mockHostname("acme.localhost");
+	localStorage.setItem("auth-access-token", "test-token");
+	localStorage.setItem("auth-refresh-token", "test-refresh");
+
+	// Default: single company, success analytics response
+	server.use(
+		http.get("/api/v1/analytics/summary", () => HttpResponse.json({ kpis: mockKpis })),
+		http.get("/api/v1/companies/", () => HttpResponse.json({ companies: [makeCompany("co-1")], nextCursor: null })),
+	);
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+function renderPage(initialEntries?: string[]) {
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<MemoryRouter initialEntries={initialEntries ?? ["/analytics"]}>
+				<AnalyticsPage />
+			</MemoryRouter>
+		</QueryClientProvider>,
+	);
+}
+
+describe("AnalyticsPage", () => {
+	it("renders KPI values from mocked API response", async () => {
+		renderPage();
+
+		await waitFor(() => expect(screen.getByText("Годовые затраты")).toBeInTheDocument());
+		expect(screen.getByText("Переплата")).toBeInTheDocument();
+		expect(screen.getByText("Экономия")).toBeInTheDocument();
+		expect(screen.getByText("Выполнено")).toBeInTheDocument();
+		expect(screen.getByText("Открытые задачи")).toBeInTheDocument();
+	});
+
+	it("shows loading skeletons while data is fetching", () => {
+		server.use(
+			http.get("/api/v1/analytics/summary", async () => {
+				await new Promise((r) => setTimeout(r, 200));
+				return HttpResponse.json({ kpis: mockKpis });
+			}),
+		);
+
+		renderPage();
+		expect(screen.getByTestId("kpi-skeletons")).toBeInTheDocument();
+	});
+
+	it("passes company URL param to analytics API", async () => {
+		let capturedUrl = "";
+		server.use(
+			http.get("/api/v1/analytics/summary", ({ request }) => {
+				capturedUrl = request.url;
+				return HttpResponse.json({ kpis: mockKpis });
+			}),
+		);
+
+		renderPage(["/analytics?company=co-1"]);
+
+		await waitFor(() => expect(capturedUrl).toContain("company=co-1"));
+	});
+
+	it("calls analytics API without company param when no URL param set", async () => {
+		let capturedUrl = "";
+		server.use(
+			http.get("/api/v1/analytics/summary", ({ request }) => {
+				capturedUrl = request.url;
+				return HttpResponse.json({ kpis: mockKpis });
+			}),
+		);
+
+		renderPage(["/analytics"]);
+
+		await waitFor(() => expect(screen.getByText("Годовые затраты")).toBeInTheDocument());
+		expect(capturedUrl).not.toContain("company=");
+	});
+
+	it("shows company filter when multiple companies are available", async () => {
+		server.use(
+			http.get("/api/v1/companies/", () =>
+				HttpResponse.json({
+					companies: [makeCompany("co-1", { name: "Альфа" }), makeCompany("co-2", { name: "Бета" })],
+					nextCursor: null,
+				}),
+			),
+		);
+
+		renderPage();
+
+		await waitFor(() => expect(screen.getByRole("combobox")).toBeInTheDocument());
+	});
+
+	it("hides company filter with a single company", async () => {
+		renderPage();
+
+		await waitFor(() => expect(screen.getByText("Годовые затраты")).toBeInTheDocument());
+		expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+	});
+
+	it("shows pending analysis footnote when pendingAnalysisCount > 0", async () => {
+		renderPage();
+
+		await waitFor(() => expect(screen.getByText(/не проанализировано/)).toBeInTheDocument());
+	});
+});

--- a/src/pages/analytics-page.test.tsx
+++ b/src/pages/analytics-page.test.tsx
@@ -39,6 +39,7 @@ beforeEach(() => {
 				отказ: 0,
 			}),
 		),
+		http.get("/api/v1/company/tasks/", () => HttpResponse.json({ count: 0, results: [], next: null, previous: null })),
 		http.get("/api/v1/companies/", () => HttpResponse.json({ companies: [makeCompany("co-1")], nextCursor: null })),
 	);
 });

--- a/src/pages/analytics-page.tsx
+++ b/src/pages/analytics-page.tsx
@@ -1,5 +1,6 @@
 import { useSearchParams } from "react-router";
 import { AnalyticsKpiStrip } from "@/components/analytics-kpi-strip";
+import { AnalyticsTasksSummary } from "@/components/analytics-tasks-summary";
 import { FolderOverpaymentChart } from "@/components/folder-overpayment-chart";
 import { ProcurementStatusDonut } from "@/components/procurement-status-donut";
 import { SupplierPipelineChart } from "@/components/supplier-pipeline-chart";
@@ -13,7 +14,9 @@ export function AnalyticsPage() {
 	const company = searchParams.get("company") ?? undefined;
 
 	const { data: companies = [] } = useProcurementCompanies();
-	const { kpis, folderBreakdown, statusBreakdown, supplierPipeline, isLoading } = useAnalyticsSummary({ company });
+	const { kpis, folderBreakdown, statusBreakdown, supplierPipeline, tasksSummary, isLoading } = useAnalyticsSummary({
+		company,
+	});
 
 	function handleCompanyChange(value: string) {
 		setSearchParams(
@@ -78,6 +81,12 @@ export function AnalyticsPage() {
 				<Skeleton className="h-64 rounded-xl" data-testid="supplier-pipeline-skeleton" />
 			) : (
 				<SupplierPipelineChart supplierPipeline={supplierPipeline} />
+			)}
+
+			{isLoading ? (
+				<Skeleton className="h-36 rounded-xl" data-testid="tasks-summary-skeleton" />
+			) : (
+				<AnalyticsTasksSummary tasksSummary={tasksSummary} />
 			)}
 		</div>
 	);

--- a/src/pages/analytics-page.tsx
+++ b/src/pages/analytics-page.tsx
@@ -2,6 +2,7 @@ import { useSearchParams } from "react-router";
 import { AnalyticsKpiStrip } from "@/components/analytics-kpi-strip";
 import { FolderOverpaymentChart } from "@/components/folder-overpayment-chart";
 import { ProcurementStatusDonut } from "@/components/procurement-status-donut";
+import { SupplierPipelineChart } from "@/components/supplier-pipeline-chart";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAnalyticsSummary } from "@/data/use-analytics";
@@ -12,7 +13,7 @@ export function AnalyticsPage() {
 	const company = searchParams.get("company") ?? undefined;
 
 	const { data: companies = [] } = useProcurementCompanies();
-	const { kpis, folderBreakdown, statusBreakdown, isLoading } = useAnalyticsSummary({ company });
+	const { kpis, folderBreakdown, statusBreakdown, supplierPipeline, isLoading } = useAnalyticsSummary({ company });
 
 	function handleCompanyChange(value: string) {
 		setSearchParams(
@@ -71,6 +72,12 @@ export function AnalyticsPage() {
 				<Skeleton className="h-64 rounded-xl" data-testid="status-donut-skeleton" />
 			) : (
 				<ProcurementStatusDonut statusBreakdown={statusBreakdown} />
+			)}
+
+			{isLoading ? (
+				<Skeleton className="h-64 rounded-xl" data-testid="supplier-pipeline-skeleton" />
+			) : (
+				<SupplierPipelineChart supplierPipeline={supplierPipeline} />
 			)}
 		</div>
 	);

--- a/src/pages/analytics-page.tsx
+++ b/src/pages/analytics-page.tsx
@@ -1,6 +1,7 @@
 import { useSearchParams } from "react-router";
 import { AnalyticsKpiStrip } from "@/components/analytics-kpi-strip";
 import { FolderOverpaymentChart } from "@/components/folder-overpayment-chart";
+import { ProcurementStatusDonut } from "@/components/procurement-status-donut";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAnalyticsSummary } from "@/data/use-analytics";
@@ -11,7 +12,7 @@ export function AnalyticsPage() {
 	const company = searchParams.get("company") ?? undefined;
 
 	const { data: companies = [] } = useProcurementCompanies();
-	const { kpis, folderBreakdown, isLoading } = useAnalyticsSummary({ company });
+	const { kpis, folderBreakdown, statusBreakdown, isLoading } = useAnalyticsSummary({ company });
 
 	function handleCompanyChange(value: string) {
 		setSearchParams(
@@ -64,6 +65,12 @@ export function AnalyticsPage() {
 				<Skeleton className="h-64 rounded-xl" data-testid="folder-chart-skeleton" />
 			) : (
 				<FolderOverpaymentChart folderBreakdown={folderBreakdown} />
+			)}
+
+			{isLoading ? (
+				<Skeleton className="h-64 rounded-xl" data-testid="status-donut-skeleton" />
+			) : (
+				<ProcurementStatusDonut statusBreakdown={statusBreakdown} />
 			)}
 		</div>
 	);

--- a/src/pages/analytics-page.tsx
+++ b/src/pages/analytics-page.tsx
@@ -1,0 +1,63 @@
+import { useSearchParams } from "react-router";
+import { AnalyticsKpiStrip } from "@/components/analytics-kpi-strip";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAnalyticsSummary } from "@/data/use-analytics";
+import { useProcurementCompanies } from "@/data/use-companies";
+
+export function AnalyticsPage() {
+	const [searchParams, setSearchParams] = useSearchParams();
+	const company = searchParams.get("company") ?? undefined;
+
+	const { data: companies = [] } = useProcurementCompanies();
+	const { kpis, isLoading } = useAnalyticsSummary({ company });
+
+	function handleCompanyChange(value: string) {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				if (value === "__all__") {
+					next.delete("company");
+				} else {
+					next.set("company", value);
+				}
+				return next;
+			},
+			{ replace: true },
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-6 p-4 sm:p-6">
+			<div className="flex items-center justify-between">
+				<h1 className="text-xl font-semibold">Аналитика</h1>
+				{companies.length > 1 && (
+					<Select value={company ?? "__all__"} onValueChange={handleCompanyChange}>
+						<SelectTrigger aria-label="Фильтр по компании">
+							<SelectValue placeholder="Все компании" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="__all__">Все компании</SelectItem>
+							{companies.map((c) => (
+								<SelectItem key={c.id} value={c.id}>
+									{c.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				)}
+			</div>
+
+			{isLoading ? (
+				<div className="grid grid-cols-2 gap-3 sm:grid-cols-5" data-testid="kpi-skeletons">
+					{Array.from({ length: 5 }).map((_, i) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+						<Skeleton key={i} className="h-28 rounded-xl" />
+					))}
+				</div>
+			) : kpis ? (
+				<AnalyticsKpiStrip kpis={kpis} />
+			) : null}
+		</div>
+	);
+}

--- a/src/pages/analytics-page.tsx
+++ b/src/pages/analytics-page.tsx
@@ -1,5 +1,6 @@
 import { useSearchParams } from "react-router";
 import { AnalyticsKpiStrip } from "@/components/analytics-kpi-strip";
+import { FolderOverpaymentChart } from "@/components/folder-overpayment-chart";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAnalyticsSummary } from "@/data/use-analytics";
@@ -10,7 +11,7 @@ export function AnalyticsPage() {
 	const company = searchParams.get("company") ?? undefined;
 
 	const { data: companies = [] } = useProcurementCompanies();
-	const { kpis, isLoading } = useAnalyticsSummary({ company });
+	const { kpis, folderBreakdown, isLoading } = useAnalyticsSummary({ company });
 
 	function handleCompanyChange(value: string) {
 		setSearchParams(
@@ -58,6 +59,12 @@ export function AnalyticsPage() {
 			) : kpis ? (
 				<AnalyticsKpiStrip kpis={kpis} />
 			) : null}
+
+			{isLoading ? (
+				<Skeleton className="h-64 rounded-xl" data-testid="folder-chart-skeleton" />
+			) : (
+				<FolderOverpaymentChart folderBreakdown={folderBreakdown} />
+			)}
 		</div>
 	);
 }

--- a/src/pages/companies-settings-page.test.tsx
+++ b/src/pages/companies-settings-page.test.tsx
@@ -1,0 +1,74 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { server } from "@/test-msw";
+import { createTestQueryClient, makeCompany, makeCompanyDetail } from "@/test-utils";
+import { CompaniesSettingsPage } from "./companies-settings-page";
+
+let queryClient: QueryClient;
+
+const mockCompanies = [
+	makeCompany("co-1", { name: "Альфа", employeeCount: 3, procurementItemCount: 10 }),
+	makeCompany("co-2", { name: "Бета", employeeCount: 1, procurementItemCount: 5 }),
+];
+
+beforeEach(() => {
+	queryClient = createTestQueryClient();
+	server.use(
+		http.get("/api/v1/companies/", () => HttpResponse.json({ companies: mockCompanies, nextCursor: null })),
+		http.get("/api/v1/companies/:id/", ({ params }) => {
+			const id = params.id as string;
+			return HttpResponse.json(makeCompanyDetail(id, { name: id === "co-1" ? "Альфа" : "Бета" }));
+		}),
+	);
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+function renderPage(initialPath = "/settings/companies") {
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<MemoryRouter initialEntries={[initialPath]}>
+				<TooltipProvider>
+					<Routes>
+						<Route path="/settings/companies" element={<CompaniesSettingsPage />} />
+					</Routes>
+				</TooltipProvider>
+			</MemoryRouter>
+		</QueryClientProvider>,
+	);
+}
+
+describe("CompaniesSettingsPage", () => {
+	test("renders page heading", async () => {
+		renderPage();
+		await waitFor(() => expect(screen.getByRole("heading", { name: "Компании" })).toBeInTheDocument());
+	});
+
+	test("renders company names in table", async () => {
+		renderPage();
+		await waitFor(() => expect(screen.getByText("Альфа")).toBeInTheDocument());
+		expect(screen.getByText("Бета")).toBeInTheDocument();
+	});
+
+	test("renders Добавить компанию button", async () => {
+		renderPage();
+		await waitFor(() => expect(screen.getByRole("button", { name: /Добавить компанию/ })).toBeInTheDocument());
+	});
+
+	test("clicking company row opens CompanyDrawer", async () => {
+		const user = userEvent.setup();
+		renderPage();
+		await waitFor(() => expect(screen.getByText("Альфа")).toBeInTheDocument());
+		await user.click(screen.getByText("Альфа"));
+		// Drawer title should appear
+		await waitFor(() => expect(screen.getByTestId("drawer-title")).toBeInTheDocument());
+	});
+});

--- a/src/pages/companies-settings-page.tsx
+++ b/src/pages/companies-settings-page.tsx
@@ -7,9 +7,18 @@ import { CompanyCreationSheet } from "@/components/company-creation-sheet";
 import { CompanyDrawer, type CompanyTab, parseCompanyTab } from "@/components/company-drawer";
 import { Button } from "@/components/ui/button";
 import type { CreateCompanyPayload } from "@/data/api-client";
-import type { CompanySummary } from "@/data/types";
+import type { CompanySortField, CompanySortState, CompanySummary } from "@/data/types";
 import { useCompanies } from "@/data/use-companies";
 import { useCreateCompany } from "@/data/use-company-detail";
+
+const SORT_FIELDS = new Set<string>(["name", "employeeCount", "procurementItemCount"]);
+
+function parseSort(params: URLSearchParams): CompanySortState | null {
+	const field = params.get("sort");
+	const dir = params.get("dir");
+	if (!field || !SORT_FIELDS.has(field) || (dir !== "asc" && dir !== "desc")) return null;
+	return { field: field as CompanySortField, direction: dir };
+}
 
 export function CompaniesSettingsPage() {
 	const [searchParams, setSearchParams] = useSearchParams();
@@ -17,8 +26,12 @@ export function CompaniesSettingsPage() {
 
 	const companyId = searchParams.get("company");
 	const activeTab = parseCompanyTab(searchParams.get("tab"));
+	const sort = parseSort(searchParams);
 
-	const { companies, isLoading, error, refetch } = useCompanies({ search: "", sort: null });
+	const { companies, hasNextPage, loadMore, isLoading, isFetchingNextPage, error, refetch } = useCompanies({
+		search: "",
+		sort,
+	});
 
 	const [creationOpen, setCreationOpen] = useState(false);
 	const createCompanyMutation = useCreateCompany();
@@ -70,6 +83,26 @@ export function CompaniesSettingsPage() {
 		});
 	}
 
+	function handleSort(field: CompanySortField) {
+		setSearchParams((prev) => {
+			const next = new URLSearchParams(prev);
+			const currentField = next.get("sort");
+			const currentDir = next.get("dir");
+			if (currentField === field) {
+				if (currentDir === "asc") {
+					next.set("dir", "desc");
+				} else {
+					next.delete("sort");
+					next.delete("dir");
+				}
+			} else {
+				next.set("sort", field);
+				next.set("dir", "asc");
+			}
+			return next;
+		});
+	}
+
 	function handleViewProcurement(company: CompanySummary) {
 		navigate(`/procurement?company=${company.id}`);
 	}
@@ -88,11 +121,12 @@ export function CompaniesSettingsPage() {
 				<CompaniesTable
 					companies={companies}
 					isLoading={isLoading}
+					isFetchingNextPage={isFetchingNextPage}
 					error={error}
-					sort={null}
-					hasNextPage={false}
-					loadMore={() => {}}
-					onSort={() => {}}
+					sort={sort}
+					hasNextPage={hasNextPage}
+					loadMore={loadMore}
+					onSort={handleSort}
 					onRowClick={handleRowClick}
 					onViewProcurement={handleViewProcurement}
 					onRetry={refetch}

--- a/src/pages/companies-settings-page.tsx
+++ b/src/pages/companies-settings-page.tsx
@@ -1,0 +1,117 @@
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { toast } from "sonner";
+import { CompaniesTable } from "@/components/companies-table";
+import { CompanyCreationSheet } from "@/components/company-creation-sheet";
+import { CompanyDrawer, type CompanyTab, parseCompanyTab } from "@/components/company-drawer";
+import { Button } from "@/components/ui/button";
+import type { CreateCompanyPayload } from "@/data/api-client";
+import type { CompanySummary } from "@/data/types";
+import { useCompanies } from "@/data/use-companies";
+import { useCreateCompany } from "@/data/use-company-detail";
+
+export function CompaniesSettingsPage() {
+	const [searchParams, setSearchParams] = useSearchParams();
+	const navigate = useNavigate();
+
+	const companyId = searchParams.get("company");
+	const activeTab = parseCompanyTab(searchParams.get("tab"));
+
+	const { companies, isLoading, error, refetch } = useCompanies({ search: "", sort: null });
+
+	const [creationOpen, setCreationOpen] = useState(false);
+	const createCompanyMutation = useCreateCompany();
+
+	function handleRowClick(company: CompanySummary) {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				next.set("company", company.id);
+				next.delete("tab");
+				return next;
+			},
+			{ replace: true },
+		);
+	}
+
+	function handleDrawerClose() {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				next.delete("company");
+				next.delete("tab");
+				return next;
+			},
+			{ replace: true },
+		);
+	}
+
+	function handleTabChange(tab: CompanyTab) {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				if (tab === "general") next.delete("tab");
+				else next.set("tab", tab);
+				return next;
+			},
+			{ replace: true },
+		);
+	}
+
+	function handleCreateCompany(data: CreateCompanyPayload) {
+		createCompanyMutation.mutate(data, {
+			onSuccess: () => {
+				setCreationOpen(false);
+			},
+			onError: () => {
+				toast.error("Не удалось создать компанию");
+			},
+		});
+	}
+
+	function handleViewProcurement(company: CompanySummary) {
+		navigate(`/procurement?company=${company.id}`);
+	}
+
+	return (
+		<div className="flex h-full flex-1 flex-col overflow-hidden bg-background text-foreground">
+			<header className="sticky top-0 z-30 flex shrink-0 items-center justify-between gap-4 border-b border-border bg-background px-4 py-2">
+				<h1 className="text-lg font-semibold tracking-tight">Компании</h1>
+				<Button size="sm" onClick={() => setCreationOpen(true)}>
+					<Plus className="size-4" aria-hidden="true" />
+					Добавить компанию
+				</Button>
+			</header>
+
+			<div className="flex-1 overflow-auto">
+				<CompaniesTable
+					companies={companies}
+					isLoading={isLoading}
+					error={error}
+					sort={null}
+					hasNextPage={false}
+					loadMore={() => {}}
+					onSort={() => {}}
+					onRowClick={handleRowClick}
+					onViewProcurement={handleViewProcurement}
+					onRetry={refetch}
+				/>
+			</div>
+
+			<CompanyDrawer
+				companyId={companyId}
+				activeTab={activeTab}
+				onClose={handleDrawerClose}
+				onTabChange={handleTabChange}
+			/>
+
+			<CompanyCreationSheet
+				open={creationOpen}
+				onOpenChange={setCreationOpen}
+				onSubmit={handleCreateCompany}
+				isPending={createCompanyMutation.isPending}
+			/>
+		</div>
+	);
+}

--- a/src/pages/employees-settings-page.test.tsx
+++ b/src/pages/employees-settings-page.test.tsx
@@ -1,0 +1,113 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import type { WorkspaceEmployee } from "@/data/workspace-types";
+import { server } from "@/test-msw";
+import { createTestQueryClient } from "@/test-utils";
+import { EmployeesSettingsPage } from "./employees-settings-page";
+
+let queryClient: QueryClient;
+
+const mockEmployees: WorkspaceEmployee[] = [
+	{
+		id: 1,
+		firstName: "Иван",
+		lastName: "Иванов",
+		patronymic: "Иванович",
+		position: "Директор",
+		role: "admin",
+		phone: "+79991234567",
+		email: "ivan@example.com",
+		companies: [{ id: "co-1", name: "Альфа" }],
+		registeredAt: "2024-01-15T10:00:00Z",
+		permissions: {
+			id: "perm-1",
+			employeeId: 1,
+			analytics: "edit",
+			procurement: "edit",
+			companies: "edit",
+			tasks: "edit",
+		},
+	},
+	{
+		id: 2,
+		firstName: "Мария",
+		lastName: "Петрова",
+		patronymic: "",
+		position: "Менеджер",
+		role: "user",
+		phone: "+79997654321",
+		email: "maria@example.com",
+		companies: [],
+		registeredAt: null, // invite pending
+		permissions: {
+			id: "perm-2",
+			employeeId: 2,
+			analytics: "none",
+			procurement: "view",
+			companies: "none",
+			tasks: "view",
+		},
+	},
+];
+
+beforeEach(() => {
+	queryClient = createTestQueryClient();
+	server.use(http.get("/api/v1/workspace/employees/", () => HttpResponse.json({ employees: mockEmployees })));
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+function renderPage(initialPath = "/settings/employees") {
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<MemoryRouter initialEntries={[initialPath]}>
+				<Routes>
+					<Route path="/settings/employees" element={<EmployeesSettingsPage />} />
+				</Routes>
+			</MemoryRouter>
+		</QueryClientProvider>,
+	);
+}
+
+describe("EmployeesSettingsPage", () => {
+	test("renders page heading", async () => {
+		renderPage();
+		await waitFor(() => expect(screen.getByRole("heading", { name: "Сотрудники" })).toBeInTheDocument());
+	});
+
+	test("renders employee names in table", async () => {
+		renderPage();
+		await waitFor(() => expect(screen.getByText("Иванов Иван")).toBeInTheDocument());
+		expect(screen.getByText("Петрова Мария")).toBeInTheDocument();
+	});
+
+	test("shows formatted date for registered employees", async () => {
+		renderPage();
+		await waitFor(() => expect(screen.getByText(/15.01.2024/)).toBeInTheDocument());
+	});
+
+	test("shows Приглашение отправлено for pending invite", async () => {
+		renderPage();
+		await waitFor(() => expect(screen.getByText("Приглашение отправлено")).toBeInTheDocument());
+	});
+
+	test("clicking row opens employee detail drawer", async () => {
+		const user = userEvent.setup();
+		renderPage();
+		await waitFor(() => expect(screen.getByText("Иванов Иван")).toBeInTheDocument());
+		await user.click(screen.getByText("Иванов Иван"));
+		await waitFor(() => expect(screen.getByTestId("employee-detail-drawer")).toBeInTheDocument());
+	});
+
+	test("renders Отправить приглашения button", async () => {
+		renderPage();
+		await waitFor(() => expect(screen.getByRole("button", { name: /Отправить приглашения/ })).toBeInTheDocument());
+	});
+});

--- a/src/pages/employees-settings-page.tsx
+++ b/src/pages/employees-settings-page.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useWorkspaceEmployees } from "@/data/use-workspace";
 import type { WorkspaceEmployee } from "@/data/workspace-types";
+import { formatAssigneeName } from "@/lib/format";
 
 const SKELETON_KEYS = ["sk-name", "sk-position", "sk-email", "sk-companies", "sk-date"] as const;
 
@@ -20,10 +21,6 @@ const dateFormatter = new Intl.DateTimeFormat("ru-RU", {
 function formatRegisteredAt(registeredAt: string | null): string {
 	if (registeredAt === null) return "Приглашение отправлено";
 	return dateFormatter.format(new Date(registeredAt));
-}
-
-function fullLastFirst(emp: WorkspaceEmployee): string {
-	return [emp.lastName, emp.firstName].filter(Boolean).join(" ");
 }
 
 export function EmployeesSettingsPage() {
@@ -96,7 +93,7 @@ export function EmployeesSettingsPage() {
 										className="cursor-pointer hover:bg-muted/50"
 										onClick={() => handleRowClick(emp)}
 									>
-										<TableCell className="font-medium">{fullLastFirst(emp)}</TableCell>
+										<TableCell className="font-medium">{formatAssigneeName(emp)}</TableCell>
 										<TableCell>{emp.position}</TableCell>
 										<TableCell>{emp.email}</TableCell>
 										<TableCell>{emp.companies.map((c) => c.name).join(", ") || "—"}</TableCell>

--- a/src/pages/employees-settings-page.tsx
+++ b/src/pages/employees-settings-page.tsx
@@ -1,0 +1,115 @@
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { useSearchParams } from "react-router";
+import { EmployeeDetailDrawer } from "@/components/employee-detail-drawer";
+import { InviteEmployeesDrawer } from "@/components/invite-employees-drawer";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useWorkspaceEmployees } from "@/data/use-workspace";
+import type { WorkspaceEmployee } from "@/data/workspace-types";
+
+const SKELETON_KEYS = ["sk-name", "sk-position", "sk-email", "sk-companies", "sk-date"] as const;
+
+const dateFormatter = new Intl.DateTimeFormat("ru-RU", {
+	day: "2-digit",
+	month: "2-digit",
+	year: "numeric",
+});
+
+function formatRegisteredAt(registeredAt: string | null): string {
+	if (registeredAt === null) return "Приглашение отправлено";
+	return dateFormatter.format(new Date(registeredAt));
+}
+
+function fullLastFirst(emp: WorkspaceEmployee): string {
+	return [emp.lastName, emp.firstName].filter(Boolean).join(" ");
+}
+
+export function EmployeesSettingsPage() {
+	const [searchParams, setSearchParams] = useSearchParams();
+	const [inviteOpen, setInviteOpen] = useState(false);
+
+	const { data, isLoading } = useWorkspaceEmployees();
+	const employees = data?.employees ?? [];
+
+	const employeeId = searchParams.get("employee");
+	const activeEmployee = employeeId ? (employees.find((e) => String(e.id) === employeeId) ?? null) : null;
+
+	function handleRowClick(emp: WorkspaceEmployee) {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				next.set("employee", String(emp.id));
+				return next;
+			},
+			{ replace: true },
+		);
+	}
+
+	function handleDrawerClose() {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				next.delete("employee");
+				return next;
+			},
+			{ replace: true },
+		);
+	}
+
+	return (
+		<div className="flex h-full flex-1 flex-col overflow-hidden bg-background text-foreground">
+			<header className="sticky top-0 z-30 flex shrink-0 items-center justify-between gap-4 border-b border-border bg-background px-4 py-2">
+				<h1 className="text-lg font-semibold tracking-tight">Сотрудники</h1>
+				<Button size="sm" onClick={() => setInviteOpen(true)}>
+					<Plus className="size-4" aria-hidden="true" />
+					Отправить приглашения
+				</Button>
+			</header>
+
+			<div className="flex-1 overflow-auto">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>ФИО</TableHead>
+							<TableHead>Должность</TableHead>
+							<TableHead>Почта</TableHead>
+							<TableHead>Компании</TableHead>
+							<TableHead>Дата регистрации</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading
+							? SKELETON_KEYS.map((key) => (
+									<TableRow key={key}>
+										{SKELETON_KEYS.map((col) => (
+											<TableCell key={col}>
+												<Skeleton className="h-4 w-full" />
+											</TableCell>
+										))}
+									</TableRow>
+								))
+							: employees.map((emp) => (
+									<TableRow
+										key={emp.id}
+										className="cursor-pointer hover:bg-muted/50"
+										onClick={() => handleRowClick(emp)}
+									>
+										<TableCell className="font-medium">{fullLastFirst(emp)}</TableCell>
+										<TableCell>{emp.position}</TableCell>
+										<TableCell>{emp.email}</TableCell>
+										<TableCell>{emp.companies.map((c) => c.name).join(", ") || "—"}</TableCell>
+										<TableCell>{formatRegisteredAt(emp.registeredAt)}</TableCell>
+									</TableRow>
+								))}
+					</TableBody>
+				</Table>
+			</div>
+
+			<EmployeeDetailDrawer employee={activeEmployee} onClose={handleDrawerClose} />
+
+			<InviteEmployeesDrawer open={inviteOpen} onOpenChange={setInviteOpen} />
+		</div>
+	);
+}

--- a/src/pages/profile-settings-page.test.tsx
+++ b/src/pages/profile-settings-page.test.tsx
@@ -1,0 +1,99 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import * as authApi from "@/data/auth-api";
+import { server } from "@/test-msw";
+import { createTestQueryClient, makeSettings } from "@/test-utils";
+import { ProfileSettingsPage } from "./profile-settings-page";
+
+const mockSettings = makeSettings();
+
+let queryClient: QueryClient;
+
+beforeEach(() => {
+	queryClient = createTestQueryClient();
+	server.use(http.get("/api/v1/auth/settings", () => HttpResponse.json(mockSettings)));
+});
+
+afterEach(() => {
+	localStorage.clear();
+	vi.restoreAllMocks();
+});
+
+function renderPage() {
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<MemoryRouter initialEntries={["/settings/profile"]}>
+				<ProfileSettingsPage />
+			</MemoryRouter>
+		</QueryClientProvider>,
+	);
+}
+
+describe("ProfileSettingsPage", () => {
+	test("renders user name and email from mock", async () => {
+		renderPage();
+		await waitFor(() => expect(screen.getByText("Иван Иванов")).toBeInTheDocument());
+		expect(screen.getByDisplayValue("ivan@example.com")).toBeInTheDocument();
+	});
+
+	test("renders editable Имя, Фамилия fields pre-filled", async () => {
+		renderPage();
+		await waitFor(() => expect(screen.getByDisplayValue("Иван")).toBeInTheDocument());
+		expect(screen.getByDisplayValue("Иванов")).toBeInTheDocument();
+	});
+
+	test("save mutation called with changed fields on submit", async () => {
+		const user = userEvent.setup();
+		let patchBody: unknown;
+		server.use(
+			http.patch("/api/v1/auth/settings", async ({ request }) => {
+				patchBody = await request.json();
+				return HttpResponse.json({ ...mockSettings, first_name: "Алексей" });
+			}),
+		);
+
+		renderPage();
+		await waitFor(() => expect(screen.getByDisplayValue("Иван")).toBeInTheDocument());
+
+		const firstNameInput = screen.getByDisplayValue("Иван");
+		await user.clear(firstNameInput);
+		await user.type(firstNameInput, "Алексей");
+
+		await user.click(screen.getByRole("button", { name: "Сохранить" }));
+
+		await waitFor(() => {
+			expect(patchBody).toEqual(expect.objectContaining({ first_name: "Алексей" }));
+		});
+	});
+
+	test("Изменить пароль button sends reset email to user email", async () => {
+		const forgotPasswordSpy = vi.spyOn(authApi, "forgotPassword").mockResolvedValue({ detail: "Sent" });
+		const user = userEvent.setup();
+		server.use(http.post("/api/v1/auth/forgot-password", () => HttpResponse.json({ detail: "Sent" })));
+
+		renderPage();
+		await waitFor(() => expect(screen.getByText("Изменить пароль")).toBeInTheDocument());
+
+		await user.click(screen.getByRole("button", { name: "Изменить пароль" }));
+
+		await waitFor(() => {
+			expect(forgotPasswordSpy).toHaveBeenCalledWith("ivan@example.com");
+		});
+	});
+
+	test("shows loading skeleton while fetching", () => {
+		server.use(
+			http.get("/api/v1/auth/settings", async () => {
+				await new Promise((r) => setTimeout(r, 200));
+				return HttpResponse.json(mockSettings);
+			}),
+		);
+		renderPage();
+		expect(screen.getByTestId("profile-skeleton")).toBeInTheDocument();
+	});
+});

--- a/src/pages/profile-settings-page.tsx
+++ b/src/pages/profile-settings-page.tsx
@@ -1,0 +1,208 @@
+import { AlertTriangle, Loader2, RotateCcw } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { FloatingInput } from "@/components/floating-input";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { extractFormErrors, forgotPassword } from "@/data/auth-api";
+import type { UserSettings } from "@/data/settings-api";
+import { useSettings, useUpdateSettings } from "@/data/use-settings";
+import { getAvatarColor } from "@/lib/avatar-colors";
+import { formatDate, getInitials } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+function stripPhonePrefix(phone: string): string {
+	return phone.startsWith("+7") ? phone.slice(2) : phone;
+}
+
+function normalizePhone(value: string): string {
+	const digits = value.replace(/\D/g, "");
+	if (digits.length === 11 && (digits[0] === "7" || digits[0] === "8")) {
+		return digits.slice(1);
+	}
+	return digits;
+}
+
+function AccountForm({ data }: { data: UserSettings }) {
+	const updateSettings = useUpdateSettings();
+	const strippedPhone = stripPhonePrefix(data.phone);
+
+	const [firstName, setFirstName] = useState(data.first_name);
+	const [lastName, setLastName] = useState(data.last_name);
+	const [patronymic, setPatronymic] = useState(data.patronymic ?? "");
+	const [phone, setPhone] = useState(strippedPhone);
+	const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+	const isDirty =
+		firstName !== data.first_name ||
+		lastName !== data.last_name ||
+		patronymic !== (data.patronymic ?? "") ||
+		phone !== strippedPhone;
+
+	function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		setFieldErrors({});
+
+		const patch: Record<string, unknown> = {};
+		if (firstName !== data.first_name) patch.first_name = firstName;
+		if (lastName !== data.last_name) patch.last_name = lastName;
+		if (patronymic !== (data.patronymic ?? "")) patch.patronymic = patronymic;
+		if (phone !== strippedPhone) patch.phone = `+7${normalizePhone(phone)}`;
+
+		updateSettings.mutate(patch, {
+			onSuccess: () => {
+				toast.success("Изменения сохранены");
+			},
+			onError: (err) => {
+				const { error, fieldErrors: fields } = extractFormErrors(err);
+				if (Object.keys(fields).length > 0) {
+					setFieldErrors(fields);
+				} else if (error) {
+					toast.error(error);
+				}
+			},
+		});
+	}
+
+	return (
+		<form onSubmit={handleSubmit} className="space-y-4">
+			<FloatingInput
+				label="Имя"
+				name="firstName"
+				value={firstName}
+				onChange={(e) => setFirstName(e.target.value)}
+				error={fieldErrors.first_name}
+				autoComplete="given-name"
+			/>
+			<FloatingInput
+				label="Фамилия"
+				name="lastName"
+				value={lastName}
+				onChange={(e) => setLastName(e.target.value)}
+				error={fieldErrors.last_name}
+				autoComplete="family-name"
+			/>
+			<FloatingInput
+				label="Отчество"
+				name="patronymic"
+				value={patronymic}
+				onChange={(e) => setPatronymic(e.target.value)}
+				error={fieldErrors.patronymic}
+				autoComplete="additional-name"
+			/>
+			<FloatingInput label="Email" name="email" type="email" value={data.email} readOnly autoComplete="email" />
+			<FloatingInput
+				label="Телефон"
+				name="phone"
+				value={phone}
+				onChange={(e) => setPhone(e.target.value)}
+				error={fieldErrors.phone}
+				prefix="+7"
+				inputMode="tel"
+				autoComplete="tel"
+			/>
+			<Button type="submit" disabled={!isDirty || updateSettings.isPending}>
+				{updateSettings.isPending && <Loader2 className="size-4 animate-spin" aria-hidden="true" />}
+				Сохранить
+			</Button>
+		</form>
+	);
+}
+
+function PasswordSection({ email }: { email: string }) {
+	const [isPending, setIsPending] = useState(false);
+
+	async function handleResetPassword() {
+		setIsPending(true);
+		try {
+			await forgotPassword(email);
+			toast.success(`Письмо отправлено на ${email}`);
+		} catch {
+			toast.error("Не удалось отправить письмо");
+		} finally {
+			setIsPending(false);
+		}
+	}
+
+	return (
+		<div>
+			<h2 className="mb-3 text-base font-semibold">Безопасность</h2>
+			<p className="mb-3 text-sm text-muted-foreground">Мы отправим ссылку для смены пароля на {email}.</p>
+			<Button type="button" variant="outline" onClick={handleResetPassword} disabled={isPending}>
+				{isPending && <Loader2 className="size-4 animate-spin" aria-hidden="true" />}
+				Изменить пароль
+			</Button>
+		</div>
+	);
+}
+
+function ProfileSkeleton() {
+	return (
+		<div data-testid="profile-skeleton" className="flex flex-col items-center gap-4 py-8">
+			<Skeleton className="size-20 rounded-full" />
+			<Skeleton className="h-6 w-40" />
+			<Skeleton className="h-4 w-32" />
+		</div>
+	);
+}
+
+export function ProfileSettingsPage() {
+	const { data, isLoading, error, refetch } = useSettings();
+
+	if (isLoading) {
+		return (
+			<div className="mx-auto w-full max-w-2xl px-4 py-8">
+				<ProfileSkeleton />
+			</div>
+		);
+	}
+
+	if (error || !data) {
+		return (
+			<div className="mx-auto flex w-full max-w-2xl flex-col items-center justify-center gap-3 px-4 py-16">
+				<AlertTriangle className="size-8 text-muted-foreground" />
+				<p className="text-sm text-muted-foreground">Не удалось загрузить профиль</p>
+				<Button variant="outline" size="sm" onClick={() => refetch()}>
+					<RotateCcw className="size-4" aria-hidden="true" />
+					Повторить
+				</Button>
+			</div>
+		);
+	}
+
+	const initials = getInitials(data.first_name, data.last_name);
+	const avatarColor = getAvatarColor(data.avatar_icon);
+
+	return (
+		<div className="mx-auto w-full max-w-2xl px-4 py-8">
+			<div className="mb-6 flex flex-col items-center gap-2">
+				<div
+					data-testid="profile-avatar"
+					className={cn(
+						"flex size-20 items-center justify-center rounded-full text-2xl font-semibold text-white",
+						avatarColor,
+					)}
+				>
+					{initials}
+				</div>
+				<h1 className="text-xl font-semibold">
+					{data.first_name} {data.last_name}
+				</h1>
+				<p className="text-sm text-muted-foreground">Зарегистрирован {formatDate(data.date_joined)}</p>
+			</div>
+
+			<div className="space-y-8">
+				<section>
+					<h2 className="mb-4 text-base font-semibold">Личные данные</h2>
+					<AccountForm key={data.date_joined} data={data} />
+				</section>
+
+				<div className="border-t border-border" />
+
+				<section>
+					<PasswordSection email={data.email} />
+				</section>
+			</div>
+		</div>
+	);
+}

--- a/src/pages/settings-layout.tsx
+++ b/src/pages/settings-layout.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { Outlet } from "react-router";
-import { DESKTOP_QUERY } from "@/components/folder-sidebar";
 import { SettingsSidebar } from "@/components/settings-sidebar";
 import { useMountEffect } from "@/hooks/use-mount-effect";
+import { DESKTOP_QUERY } from "@/lib/breakpoints";
 
 const LS_SETTINGS_SIDEBAR_KEY = "settings-sidebar-open";
 

--- a/src/pages/settings-layout.tsx
+++ b/src/pages/settings-layout.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { Outlet } from "react-router";
+import { DESKTOP_QUERY } from "@/components/folder-sidebar";
+import { SettingsSidebar } from "@/components/settings-sidebar";
+import { useMountEffect } from "@/hooks/use-mount-effect";
+
+const LS_SETTINGS_SIDEBAR_KEY = "settings-sidebar-open";
+
+function useSettingsSidebarState() {
+	const [open, setOpen] = useState(() => {
+		const stored = localStorage.getItem(LS_SETTINGS_SIDEBAR_KEY);
+		if (stored !== null) return stored === "true";
+		return window.matchMedia(DESKTOP_QUERY).matches;
+	});
+
+	function handleOpenChange(next: boolean) {
+		if (window.matchMedia(DESKTOP_QUERY).matches) {
+			localStorage.setItem(LS_SETTINGS_SIDEBAR_KEY, String(next));
+		}
+		setOpen(next);
+	}
+
+	return { open, handleOpenChange };
+}
+
+export function SettingsLayout() {
+	const { open, handleOpenChange } = useSettingsSidebarState();
+
+	useMountEffect(() => {
+		const mql = window.matchMedia(DESKTOP_QUERY);
+		const handler = (e: MediaQueryListEvent) => {
+			if (e.matches) {
+				const stored = localStorage.getItem(LS_SETTINGS_SIDEBAR_KEY);
+				handleOpenChange(stored !== "false");
+			} else {
+				handleOpenChange(false);
+			}
+		};
+		mql.addEventListener("change", handler);
+		return () => mql.removeEventListener("change", handler);
+	});
+
+	return (
+		<div className="flex h-full min-h-0 flex-1" data-testid="settings-layout">
+			<SettingsSidebar open={open} onOpenChange={handleOpenChange} />
+			<main className="flex min-w-0 flex-1 flex-col overflow-y-auto">
+				<Outlet />
+			</main>
+		</div>
+	);
+}


### PR DESCRIPTION
Implements the analytics dashboard and the full settings section.

- Analytics page with KPI strip, folder overpayment chart, procurement status donut, supplier pipeline chart, and tasks summary card (closes #153, closes #154, closes #155, closes #156, closes #157, closes #158)
- Settings section: `/settings` layout with sidebar, profile, companies, and employees pages + avatar menu updates (closes #159)
- Extracts `DESKTOP_QUERY` to `lib/breakpoints`, deduplicates labels and name formatters