### PR TITLE
RALPH: TaskRow showQuestionCount prop (#182)

### DIFF
--- a/src/components/task-table.test.tsx
+++ b/src/components/task-table.test.tsx
@@ -52,11 +52,11 @@ afterEach(() => {
 	localStorage.clear();
 });
 
-function renderTable(onTaskClick = vi.fn(), isMobile = false) {
+function renderTable(onTaskClick = vi.fn(), isMobile = false, showQuestionCount = false) {
 	return render(
 		<QueryClientProvider client={queryClient}>
 			<MemoryRouter>
-				<TaskTable onTaskClick={onTaskClick} isMobile={isMobile} />
+				<TaskTable onTaskClick={onTaskClick} isMobile={isMobile} showQuestionCount={showQuestionCount} />
 			</MemoryRouter>
 		</QueryClientProvider>,
 	);
@@ -119,6 +119,77 @@ describe("TaskTable desktop", () => {
 		);
 		renderTable();
 		expect(screen.getAllByTestId("skeleton-row").length).toBeGreaterThan(0);
+	});
+});
+
+describe("TaskRow question count", () => {
+	it("renders question count with icon when showQuestionCount is true and questionCount > 0", async () => {
+		const taskWithQuestions = makeTask("task-q", {
+			name: "Задача с вопросами",
+			status: "assigned",
+			questionCount: 3,
+		});
+		server.use(
+			http.get("/api/v1/company/tasks/board/", () =>
+				HttpResponse.json({
+					assigned: { results: [taskWithQuestions], next: null, count: 1 },
+					in_progress: { results: [], next: null, count: 0 },
+					completed: { results: [], next: null, count: 0 },
+					archived: { results: [], next: null, count: 0 },
+				}),
+			),
+		);
+		renderTable(vi.fn(), false, true);
+		await waitFor(() => {
+			expect(screen.getByTestId("task-row-task-q")).toBeInTheDocument();
+		});
+		expect(screen.getByText("3 вопроса")).toBeInTheDocument();
+	});
+
+	it("does not render question count when showQuestionCount is false", async () => {
+		const taskWithQuestions = makeTask("task-q2", {
+			name: "Задача без счётчика",
+			status: "assigned",
+			questionCount: 3,
+		});
+		server.use(
+			http.get("/api/v1/company/tasks/board/", () =>
+				HttpResponse.json({
+					assigned: { results: [taskWithQuestions], next: null, count: 1 },
+					in_progress: { results: [], next: null, count: 0 },
+					completed: { results: [], next: null, count: 0 },
+					archived: { results: [], next: null, count: 0 },
+				}),
+			),
+		);
+		renderTable();
+		await waitFor(() => {
+			expect(screen.getByTestId("task-row-task-q2")).toBeInTheDocument();
+		});
+		expect(screen.queryByText("3 вопроса")).not.toBeInTheDocument();
+	});
+
+	it("does not render question count when questionCount is 0", async () => {
+		const taskNoQuestions = makeTask("task-q3", {
+			name: "Задача без счётчика 2",
+			status: "assigned",
+			questionCount: 0,
+		});
+		server.use(
+			http.get("/api/v1/company/tasks/board/", () =>
+				HttpResponse.json({
+					assigned: { results: [taskNoQuestions], next: null, count: 1 },
+					in_progress: { results: [], next: null, count: 0 },
+					completed: { results: [], next: null, count: 0 },
+					archived: { results: [], next: null, count: 0 },
+				}),
+			),
+		);
+		renderTable(vi.fn(), false, true);
+		await waitFor(() => {
+			expect(screen.getByTestId("task-row-task-q3")).toBeInTheDocument();
+		});
+		expect(screen.queryByText(/^\d+\s+вопрос/)).not.toBeInTheDocument();
 	});
 });
 

--- a/src/components/task-table.tsx
+++ b/src/components/task-table.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, LoaderCircle } from "lucide-react";
+import { ChevronDown, ChevronRight, LoaderCircle, MessageCircleQuestion } from "lucide-react";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -13,7 +13,7 @@ import {
 import { useAllTasks, useTaskColumns } from "@/data/use-tasks";
 import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { getAvatarColor } from "@/lib/avatar-colors";
-import { formatAssigneeName, formatDayMonth, getInitials } from "@/lib/format";
+import { formatAssigneeName, formatDayMonth, getInitials, pluralizeRu } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 const STATUS_BADGE_VARIANT = {
@@ -30,6 +30,7 @@ interface TaskTableProps {
 	onTaskClick?: (taskId: string) => void;
 	filterParams?: TaskFilterParams;
 	isMobile?: boolean;
+	showQuestionCount?: boolean;
 }
 
 // ── Mobile card ───────────────────────────────────────────────────────────────
@@ -105,7 +106,15 @@ function LoadMoreSentinel({ loadMore }: { loadMore: () => void }) {
 
 // ── Desktop grouped row ───────────────────────────────────────────────────────
 
-function TaskRow({ task, onTaskClick }: { task: Task; onTaskClick?: (id: string) => void }) {
+function TaskRow({
+	task,
+	onTaskClick,
+	showQuestionCount,
+}: {
+	task: Task;
+	onTaskClick?: (id: string) => void;
+	showQuestionCount?: boolean;
+}) {
 	const now = new Date();
 	const isOverdue = new Date(task.deadlineAt) < now;
 	const StatusIcon = STATUS_ICONS[task.status];
@@ -124,6 +133,12 @@ function TaskRow({ task, onTaskClick }: { task: Task; onTaskClick?: (id: string)
 		>
 			<StatusIcon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
 			<span className="flex-1 truncate">{task.name}</span>
+			{showQuestionCount && task.questionCount > 0 && (
+				<span className="inline-flex items-center gap-1 shrink-0 text-xs text-muted-foreground">
+					<MessageCircleQuestion className="size-3.5" aria-hidden="true" />
+					{pluralizeRu(task.questionCount, "вопрос", "вопроса", "вопросов")}
+				</span>
+			)}
 			{task.assignee ? (
 				<span
 					role="img"
@@ -157,7 +172,11 @@ function TaskRow({ task, onTaskClick }: { task: Task; onTaskClick?: (id: string)
 
 // ── Desktop grouped table ─────────────────────────────────────────────────────
 
-function TaskTableDesktop({ onTaskClick, filterParams }: Pick<TaskTableProps, "onTaskClick" | "filterParams">) {
+function TaskTableDesktop({
+	onTaskClick,
+	filterParams,
+	showQuestionCount,
+}: Pick<TaskTableProps, "onTaskClick" | "filterParams" | "showQuestionCount">) {
 	const columns = useTaskColumns(filterParams);
 	const isLoading = columns.assigned.isLoading;
 
@@ -214,7 +233,14 @@ function TaskTableDesktop({ onTaskClick, filterParams }: Pick<TaskTableProps, "o
 												<Skeleton className="h-4 w-10" />
 											</div>
 										))
-									: col.tasks.map((task) => <TaskRow key={task.id} task={task} onTaskClick={onTaskClick} />)}
+									: col.tasks.map((task) => (
+											<TaskRow
+												key={task.id}
+												task={task}
+												onTaskClick={onTaskClick}
+												showQuestionCount={showQuestionCount}
+											/>
+										))}
 								{!isLoading && col.hasNextPage && <LoadMoreSentinel loadMore={col.loadMore} />}
 							</div>
 						)}
@@ -280,9 +306,11 @@ function TaskTableMobile({ onTaskClick, filterParams }: Pick<TaskTableProps, "on
 
 // ── Public component ──────────────────────────────────────────────────────────
 
-export function TaskTable({ onTaskClick, filterParams, isMobile }: TaskTableProps) {
+export function TaskTable({ onTaskClick, filterParams, isMobile, showQuestionCount }: TaskTableProps) {
 	if (isMobile) {
 		return <TaskTableMobile onTaskClick={onTaskClick} filterParams={filterParams} />;
 	}
-	return <TaskTableDesktop onTaskClick={onTaskClick} filterParams={filterParams} />;
+	return (
+		<TaskTableDesktop onTaskClick={onTaskClick} filterParams={filterParams} showQuestionCount={showQuestionCount} />
+	);
 }


### PR DESCRIPTION
## Summary

- Add optional `showQuestionCount` prop to `TaskRow` — when true and `questionCount > 0`, renders the count with `MessageCircleQuestion` icon inline before the assignee avatar
- Prop threaded through `TaskTable` → `TaskTableDesktop` → `TaskRow`
- Matches existing icon pattern from `TaskCard`
- Existing usage (without the prop) unchanged

Closes #182

## Test plan

- [x] 3 new tests in `task-table.test.tsx`: renders count when enabled + count > 0, hidden when disabled, hidden when count = 0
- [x] All 1038 tests passing
- [x] typecheck/lint/knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)