### PR TITLE
Current supplier: data model, card, form section, select & archive flows

### DIFF
--- a/src/components/add-positions-drawer.test.tsx
+++ b/src/components/add-positions-drawer.test.tsx
@@ -819,4 +819,143 @@ describe("AddPositionsDrawer", () => {
 
 		expect(screen.getByPlaceholderText("Название позиции *")).toHaveValue("");
 	});
+
+	// --- Current supplier form section ---
+
+	test("current supplier section is collapsed by default", () => {
+		renderDrawer();
+		expect(screen.getByRole("button", { name: "Текущий поставщик" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Текущий поставщик" })).toHaveAttribute("aria-expanded", "false");
+		expect(screen.queryByPlaceholderText("Название компании")).not.toBeInTheDocument();
+	});
+
+	test("current supplier section expands on click", async () => {
+		renderDrawer();
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "Текущий поставщик" }));
+
+		expect(screen.getByRole("button", { name: "Текущий поставщик" })).toHaveAttribute("aria-expanded", "true");
+		expect(screen.getByPlaceholderText("Название компании")).toBeInTheDocument();
+		expect(screen.getByLabelText("Доставка, ₽")).toBeInTheDocument();
+		expect(screen.getByLabelText("Отсрочка, дн.")).toBeInTheDocument();
+		expect(screen.getByLabelText("Цена/ед., ₽")).toBeInTheDocument();
+		expect(screen.getByLabelText("ТСО, ₽")).toBeInTheDocument();
+	});
+
+	test("current supplier section collapses on second click", async () => {
+		renderDrawer();
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "Текущий поставщик" }));
+		await user.click(screen.getByRole("button", { name: "Текущий поставщик" }));
+
+		expect(screen.getByRole("button", { name: "Текущий поставщик" })).toHaveAttribute("aria-expanded", "false");
+		expect(screen.queryByPlaceholderText("Название компании")).not.toBeInTheDocument();
+	});
+
+	test("submit with all current supplier fields empty sends no currentSupplier", async () => {
+		const onSubmit = vi.fn();
+		renderDrawer({ onSubmit });
+		const user = userEvent.setup();
+
+		// Expand section but leave all fields empty
+		await user.click(screen.getByRole("button", { name: "Текущий поставщик" }));
+		await user.type(screen.getByPlaceholderText("Название позиции *"), "Item");
+		await selectCompany(user);
+		await user.click(screen.getByRole("button", { name: "Создать позиции" }));
+
+		expect(onSubmit.mock.calls[0][0][0].currentSupplier).toBeUndefined();
+	});
+
+	test("submit with current supplier fields populated includes currentSupplier", async () => {
+		const onSubmit = vi.fn();
+		renderDrawer({ onSubmit });
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "Текущий поставщик" }));
+		await user.type(screen.getByPlaceholderText("Название компании"), "МеталлТрейд");
+		await user.type(screen.getByLabelText("Доставка, ₽"), "5000");
+		await user.type(screen.getByLabelText("Отсрочка, дн."), "30");
+		await user.type(screen.getByLabelText("Цена/ед., ₽"), "1200");
+		await user.type(screen.getByLabelText("ТСО, ₽"), "15000");
+
+		await user.type(screen.getByPlaceholderText("Название позиции *"), "Item");
+		await selectCompany(user);
+		await user.click(screen.getByRole("button", { name: "Создать позиции" }));
+
+		expect(onSubmit).toHaveBeenCalledWith([
+			expect.objectContaining({
+				currentSupplier: {
+					companyName: "МеталлТрейд",
+					deliveryCost: 5000,
+					deferralDays: 30,
+					pricePerUnit: 1200,
+					tco: 15000,
+				},
+			}),
+		]);
+	});
+
+	test("submit with only company name sends currentSupplier with null numerics", async () => {
+		const onSubmit = vi.fn();
+		renderDrawer({ onSubmit });
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "Текущий поставщик" }));
+		await user.type(screen.getByPlaceholderText("Название компании"), "СтройМаркет");
+
+		await user.type(screen.getByPlaceholderText("Название позиции *"), "Item");
+		await selectCompany(user);
+		await user.click(screen.getByRole("button", { name: "Создать позиции" }));
+
+		expect(onSubmit).toHaveBeenCalledWith([
+			expect.objectContaining({
+				currentSupplier: {
+					companyName: "СтройМаркет",
+					deliveryCost: null,
+					deferralDays: 0,
+					pricePerUnit: null,
+					tco: null,
+				},
+			}),
+		]);
+	});
+
+	test("current supplier section resets after submit", async () => {
+		const onSubmit = vi.fn();
+		renderDrawer({ onSubmit });
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "Текущий поставщик" }));
+		await user.type(screen.getByPlaceholderText("Название компании"), "Test");
+
+		await user.type(screen.getByPlaceholderText("Название позиции *"), "Item");
+		await selectCompany(user);
+		await user.click(screen.getByRole("button", { name: "Создать позиции" }));
+
+		// Section collapses and fields reset
+		expect(screen.getByRole("button", { name: "Текущий поставщик" })).toHaveAttribute("aria-expanded", "false");
+		expect(screen.queryByPlaceholderText("Название компании")).not.toBeInTheDocument();
+	});
+
+	test("dirty detection: filling current supplier field triggers confirmation", async () => {
+		const onOpenChange = vi.fn();
+		renderDrawer({ onOpenChange });
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "Текущий поставщик" }));
+		await user.type(screen.getByPlaceholderText("Название компании"), "Test");
+		await user.click(screen.getByRole("button", { name: "Отмена" }));
+
+		expect(screen.getByText("Закрыть без сохранения?")).toBeInTheDocument();
+	});
+
+	test("current supplier section positioned after positions, before company", () => {
+		renderDrawer();
+		const toggle = screen.getByRole("button", { name: "Текущий поставщик" });
+		const companyHeader = screen.getByText("Компания");
+		// Toggle should appear before the company section in DOM
+		expect(toggle.compareDocumentPosition(companyHeader) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+	});
 });

--- a/src/components/add-positions-drawer.tsx
+++ b/src/components/add-positions-drawer.tsx
@@ -1,4 +1,4 @@
-import { CircleHelp, Plus, Trash2, X } from "lucide-react";
+import { ChevronDown, ChevronRight, CircleHelp, Plus, Trash2, X } from "lucide-react";
 import { useRef, useState } from "react";
 import {
 	AlertDialog,
@@ -19,6 +19,7 @@ import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetT
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type {
+	CurrentSupplier,
 	DeliveryType,
 	FrequencyPeriod,
 	NewItemInput,
@@ -138,6 +139,12 @@ export function AddPositionsDrawer({ open, onOpenChange, onSubmit }: AddPosition
 	const [selectedCompanyId, setSelectedCompanyId] = useState<string>("");
 	const [selectedAddressIds, setSelectedAddressIds] = useState<string[]>([]);
 	const [companyError, setCompanyError] = useState<string>("");
+	const [csExpanded, setCsExpanded] = useState(false);
+	const [csCompanyName, setCsCompanyName] = useState("");
+	const [csDeliveryCost, setCsDeliveryCost] = useState("");
+	const [csDeferralDays, setCsDeferralDays] = useState("");
+	const [csPricePerUnit, setCsPricePerUnit] = useState("");
+	const [csTco, setCsTco] = useState("");
 	const pendingFocusKey = useRef<string | null>(null);
 	const nameRefs = useRef<Map<string, HTMLInputElement>>(new Map());
 	const fileInputRef = useRef<HTMLInputElement>(null);
@@ -160,7 +167,12 @@ export function AddPositionsDrawer({ open, onOpenChange, onSubmit }: AddPosition
 		delivery.analoguesAllowed !== null ||
 		delivery.additionalInfo !== "" ||
 		delivery.monitoringPeriod !== "quarter" ||
-		files.length > 0;
+		files.length > 0 ||
+		csCompanyName !== "" ||
+		csDeliveryCost !== "" ||
+		csDeferralDays !== "" ||
+		csPricePerUnit !== "" ||
+		csTco !== "";
 
 	function resetForm() {
 		setPositions([createEmptyRow()]);
@@ -172,10 +184,28 @@ export function AddPositionsDrawer({ open, onOpenChange, onSubmit }: AddPosition
 		setCompanyError("");
 		setDelivery(createDefaultDelivery());
 		setFiles([]);
+		setCsExpanded(false);
+		setCsCompanyName("");
+		setCsDeliveryCost("");
+		setCsDeferralDays("");
+		setCsPricePerUnit("");
+		setCsTco("");
 	}
 
 	function updateDelivery<K extends keyof DeliveryState>(field: K, value: DeliveryState[K]) {
 		setDelivery((prev) => ({ ...prev, [field]: value }));
+	}
+
+	function buildCurrentSupplier(): CurrentSupplier | undefined {
+		const hasAnyValue = csCompanyName || csDeliveryCost || csDeferralDays || csPricePerUnit || csTco;
+		if (!hasAnyValue) return undefined;
+		return {
+			companyName: csCompanyName,
+			deliveryCost: csDeliveryCost ? Number(csDeliveryCost) : null,
+			deferralDays: csDeferralDays ? Number(csDeferralDays) : 0,
+			pricePerUnit: csPricePerUnit ? Number(csPricePerUnit) : null,
+			tco: csTco ? Number(csTco) : null,
+		};
 	}
 
 	function buildSharedFields(): Partial<NewItemInput> {
@@ -255,6 +285,7 @@ export function AddPositionsDrawer({ open, onOpenChange, onSubmit }: AddPosition
 		}
 
 		const deliveryFields = buildSharedFields();
+		const currentSupplier = buildCurrentSupplier();
 
 		const items: NewItemInput[] = positions.map((p) => ({
 			name: p.name.trim(),
@@ -263,6 +294,7 @@ export function AddPositionsDrawer({ open, onOpenChange, onSubmit }: AddPosition
 			annualQuantity: p.quantity ? Number(p.quantity) : undefined,
 			currentPrice: p.price ? Number(p.price) : undefined,
 			...deliveryFields,
+			...(currentSupplier ? { currentSupplier } : {}),
 		}));
 
 		onSubmit(items);
@@ -464,6 +496,84 @@ export function AddPositionsDrawer({ open, onOpenChange, onSubmit }: AddPosition
 								<Plus aria-hidden="true" />
 								Добавить позицию
 							</Button>
+						</div>
+
+						{/* ── Текущий поставщик (collapsible) ── */}
+						<div className="mt-4 rounded-lg border border-border">
+							<button
+								type="button"
+								className="flex w-full items-center gap-2 px-3 py-2.5 text-sm font-medium hover:bg-muted/50"
+								aria-expanded={csExpanded}
+								onClick={() => setCsExpanded((prev) => !prev)}
+							>
+								{csExpanded ? (
+									<ChevronDown className="size-4" aria-hidden="true" />
+								) : (
+									<ChevronRight className="size-4" aria-hidden="true" />
+								)}
+								Текущий поставщик
+							</button>
+							{csExpanded && (
+								<div className="flex flex-col gap-3 border-t border-border px-3 pb-3 pt-2">
+									<Input
+										placeholder="Название компании"
+										value={csCompanyName}
+										onChange={(e) => setCsCompanyName(e.target.value)}
+										spellCheck={false}
+										autoComplete="off"
+									/>
+									<div className="grid grid-cols-2 gap-3">
+										<div>
+											<Input
+												type="number"
+												inputMode="numeric"
+												min={0}
+												value={csDeliveryCost}
+												onChange={(e) => setCsDeliveryCost(e.target.value)}
+												aria-label="Доставка, ₽"
+												placeholder="Доставка"
+												autoComplete="off"
+											/>
+										</div>
+										<div>
+											<Input
+												type="number"
+												inputMode="numeric"
+												min={0}
+												value={csDeferralDays}
+												onChange={(e) => setCsDeferralDays(e.target.value)}
+												aria-label="Отсрочка, дн."
+												placeholder="Отсрочка"
+												autoComplete="off"
+											/>
+										</div>
+										<div>
+											<Input
+												type="number"
+												inputMode="numeric"
+												min={0}
+												value={csPricePerUnit}
+												onChange={(e) => setCsPricePerUnit(e.target.value)}
+												aria-label="Цена/ед., ₽"
+												placeholder="Цена/ед."
+												autoComplete="off"
+											/>
+										</div>
+										<div>
+											<Input
+												type="number"
+												inputMode="numeric"
+												min={0}
+												value={csTco}
+												onChange={(e) => setCsTco(e.target.value)}
+												aria-label="ТСО, ₽"
+												placeholder="ТСО"
+												autoComplete="off"
+											/>
+										</div>
+									</div>
+								</div>
+							)}
 						</div>
 
 						<p className="mt-4 rounded-lg bg-muted px-3 py-2 text-xs max-md:text-[0.65rem] text-muted-foreground">

--- a/src/components/current-supplier-card.test.tsx
+++ b/src/components/current-supplier-card.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import type { CurrentSupplier } from "@/data/types";
+
+import { CurrentSupplierCard } from "./current-supplier-card";
+
+const FULL_SUPPLIER: CurrentSupplier = {
+	companyName: "МеталлТрейд",
+	deliveryCost: 15000,
+	deferralDays: 30,
+	pricePerUnit: 4500,
+	tco: 5400000,
+};
+
+describe("CurrentSupplierCard", () => {
+	test("renders all 5 fields with correct formatting", () => {
+		render(<CurrentSupplierCard currentSupplier={FULL_SUPPLIER} />);
+
+		expect(screen.getByText("Текущий поставщик")).toBeInTheDocument();
+		expect(screen.getByText("МеталлТрейд")).toBeInTheDocument();
+		// deliveryCost 15000 → "15 000 ₽" (Intl.NumberFormat ru-RU)
+		expect(screen.getByText(/15\s?000\s?₽/)).toBeInTheDocument();
+		// deferralDays 30 → "30 дней"
+		expect(screen.getByText(/30\s?дней/)).toBeInTheDocument();
+		// pricePerUnit 4500 → "4 500 ₽"
+		expect(screen.getByText(/4\s?500\s?₽/)).toBeInTheDocument();
+		// tco 5400000 → "5 400 000 ₽"
+		expect(screen.getByText(/5\s?400\s?000\s?₽/)).toBeInTheDocument();
+	});
+
+	test("displays delivery as 'Включена' when deliveryCost is 0", () => {
+		render(<CurrentSupplierCard currentSupplier={{ ...FULL_SUPPLIER, deliveryCost: 0 }} />);
+		expect(screen.getByText("Включена")).toBeInTheDocument();
+	});
+
+	test("handles null values for optional numeric fields", () => {
+		render(
+			<CurrentSupplierCard
+				currentSupplier={{
+					companyName: "ТестКомпания",
+					deliveryCost: null,
+					deferralDays: 0,
+					pricePerUnit: null,
+					tco: null,
+				}}
+			/>,
+		);
+
+		expect(screen.getByText("ТестКомпания")).toBeInTheDocument();
+		// null delivery → "Самовывоз"
+		expect(screen.getByText("Самовывоз")).toBeInTheDocument();
+		// deferralDays 0 → "Предоплата"
+		expect(screen.getByText("Предоплата")).toBeInTheDocument();
+		// null pricePerUnit and tco → "—"
+		const dashes = screen.getAllByText("—");
+		expect(dashes.length).toBeGreaterThanOrEqual(2);
+	});
+
+	test("has muted background, border, and rounded styling", () => {
+		const { container } = render(<CurrentSupplierCard currentSupplier={FULL_SUPPLIER} />);
+		const card = container.firstElementChild as HTMLElement;
+		expect(card.className).toMatch(/bg-muted/);
+		expect(card.className).toMatch(/border/);
+		expect(card.className).toMatch(/rounded-lg/);
+	});
+});

--- a/src/components/current-supplier-card.tsx
+++ b/src/components/current-supplier-card.tsx
@@ -1,0 +1,30 @@
+import type { CurrentSupplier } from "@/data/types";
+import { formatCurrency, formatDeferral, formatDelivery } from "@/lib/format";
+
+interface CurrentSupplierCardProps {
+	currentSupplier: CurrentSupplier;
+}
+
+const FIELDS: { label: string; render: (s: CurrentSupplier) => string }[] = [
+	{ label: "Компания", render: (s) => s.companyName },
+	{ label: "Доставка", render: (s) => formatDelivery(s.deliveryCost) },
+	{ label: "Отсрочка", render: (s) => formatDeferral(s.deferralDays) },
+	{ label: "Цена/ед.", render: (s) => formatCurrency(s.pricePerUnit) },
+	{ label: "ТСО", render: (s) => formatCurrency(s.tco) },
+];
+
+export function CurrentSupplierCard({ currentSupplier }: CurrentSupplierCardProps) {
+	return (
+		<div className="mb-3 rounded-lg border bg-muted px-4 py-3">
+			<p className="mb-2 text-xs font-medium text-muted-foreground">Текущий поставщик</p>
+			<div className="grid grid-cols-5 gap-3">
+				{FIELDS.map(({ label, render }) => (
+					<div key={label}>
+						<p className="text-xs text-muted-foreground">{label}</p>
+						<p className="text-sm font-medium tabular-nums">{render(currentSupplier)}</p>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/src/components/procurement-item-drawer.test.tsx
+++ b/src/components/procurement-item-drawer.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { MemoryRouter, useSearchParams } from "react-router";
@@ -705,5 +705,88 @@ describe("ProcurementItemDrawer", () => {
 		});
 
 		expect(screen.queryByText("Текущий поставщик")).not.toBeInTheDocument();
+	});
+
+	test("context menu shows Выбрать поставщика for получено_кп supplier", async () => {
+		renderDrawer(["/procurement?item=item-1"]);
+		await waitFor(() => {
+			expect(screen.getAllByRole("row").length).toBe(11);
+		});
+
+		// First data row is получено_кп (STATUS_PATTERN[0])
+		const rows = screen.getAllByRole("row");
+		fireEvent.contextMenu(rows[1]);
+		expect(screen.getByText("Выбрать поставщика")).toBeInTheDocument();
+	});
+
+	test("context menu hides Выбрать поставщика for non-получено_кп supplier", async () => {
+		renderDrawer(["/procurement?item=item-1"]);
+		await waitFor(() => {
+			expect(screen.getAllByRole("row").length).toBe(11);
+		});
+
+		// Second data row is письмо_не_отправлено (STATUS_PATTERN[1])
+		const rows = screen.getAllByRole("row");
+		fireEvent.contextMenu(rows[2]);
+		expect(screen.queryByText("Выбрать поставщика")).not.toBeInTheDocument();
+	});
+
+	test("clicking Выбрать поставщика opens confirmation dialog", async () => {
+		const user = userEvent.setup();
+		renderDrawer(["/procurement?item=item-1"]);
+		await waitFor(() => {
+			expect(screen.getAllByRole("row").length).toBe(11);
+		});
+
+		const rows = screen.getAllByRole("row");
+		fireEvent.contextMenu(rows[1]);
+		await user.click(screen.getByText("Выбрать поставщика"));
+
+		expect(screen.getByText(/текущим поставщиком/)).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Подтвердить" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Отмена" })).toBeInTheDocument();
+	});
+
+	test("cancelling select supplier dialog does not change current supplier", async () => {
+		const user = userEvent.setup();
+		renderDrawer(["/procurement?item=item-1"]);
+		await waitFor(() => {
+			expect(screen.getAllByRole("row").length).toBe(11);
+		});
+
+		const rows = screen.getAllByRole("row");
+		fireEvent.contextMenu(rows[1]);
+		await user.click(screen.getByText("Выбрать поставщика"));
+		await user.click(screen.getByRole("button", { name: "Отмена" }));
+
+		// Dialog should be gone
+		expect(screen.queryByText(/текущим поставщиком/)).not.toBeInTheDocument();
+		// Original current supplier still shown
+		expect(screen.getByText("МеталлТрейд")).toBeInTheDocument();
+	});
+
+	test("confirming select supplier dialog fires mutation and closes dialog", async () => {
+		const user = userEvent.setup();
+		renderDrawer(["/procurement?item=item-1"]);
+		await waitFor(() => {
+			expect(screen.getAllByRole("row").length).toBe(11);
+		});
+
+		// Verify current supplier before selection
+		expect(screen.getByText("МеталлТрейд")).toBeInTheDocument();
+
+		const rows = screen.getAllByRole("row");
+		fireEvent.contextMenu(rows[1]);
+		await user.click(screen.getByText("Выбрать поставщика"));
+
+		// Confirmation dialog is open
+		expect(screen.getByText(/текущим поставщиком/)).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Подтвердить" }));
+
+		// Dialog should close
+		await waitFor(() => {
+			expect(screen.queryByText(/текущим поставщиком/)).not.toBeInTheDocument();
+		});
 	});
 });

--- a/src/components/procurement-item-drawer.test.tsx
+++ b/src/components/procurement-item-drawer.test.tsx
@@ -671,4 +671,39 @@ describe("ProcurementItemDrawer", () => {
 			expect(screen.getByText("Согласовать цену")).toBeInTheDocument();
 		});
 	});
+
+	test("suppliers tab shows current supplier card when item has currentSupplier", async () => {
+		renderDrawer(["/procurement?item=item-1"]);
+
+		// item-1 mock has currentSupplier with companyName "МеталлТрейд"
+		await waitFor(() => {
+			expect(screen.getByText("Текущий поставщик")).toBeInTheDocument();
+		});
+		expect(screen.getByText("МеталлТрейд")).toBeInTheDocument();
+	});
+
+	test("suppliers tab hides current supplier card when item has no currentSupplier", async () => {
+		const itemNoSupplier: ProcurementItem = {
+			...TEST_ITEM,
+			id: "item-2",
+			name: "Труба профильная",
+		};
+		render(
+			<QueryClientProvider client={queryClient}>
+				<TooltipProvider>
+					<MemoryRouter initialEntries={["/procurement?item=item-2"]}>
+						<ProcurementItemDrawer item={itemNoSupplier} />
+						<UrlSpy />
+					</MemoryRouter>
+				</TooltipProvider>
+			</QueryClientProvider>,
+		);
+
+		// Wait for suppliers table to load
+		await waitFor(() => {
+			expect(screen.getAllByRole("columnheader").length).toBeGreaterThan(0);
+		});
+
+		expect(screen.queryByText("Текущий поставщик")).not.toBeInTheDocument();
+	});
 });

--- a/src/components/procurement-item-drawer.test.tsx
+++ b/src/components/procurement-item-drawer.test.tsx
@@ -302,6 +302,15 @@ describe("ProcurementItemDrawer", () => {
 		expect(checkboxes).toHaveLength(11);
 	});
 
+	test("suppliers tab has archive filter toggle", async () => {
+		renderDrawer(["/procurement?item=item-1"]);
+		await waitFor(() => {
+			expect(screen.getAllByRole("row").length).toBe(11);
+		});
+		const btn = screen.getByRole("button", { name: "Архив" });
+		expect(btn).toHaveAttribute("aria-pressed", "false");
+	});
+
 	test("clicking supplier row opens supplier detail drawer with &supplier= in URL", async () => {
 		const user = userEvent.setup();
 		renderDrawer(["/procurement?item=item-1"]);

--- a/src/components/procurement-item-drawer.tsx
+++ b/src/components/procurement-item-drawer.tsx
@@ -8,6 +8,16 @@ import { SupplierDetailDrawer } from "@/components/supplier-detail-drawer";
 import { SuppliersTable } from "@/components/suppliers-table";
 import { TaskDrawer } from "@/components/task-drawer";
 import { LoadMoreSentinel, TaskRow } from "@/components/task-table";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Input } from "@/components/ui/input";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -20,6 +30,7 @@ import {
 	useArchiveSupplier,
 	useDeleteSuppliers,
 	useInfiniteSuppliers,
+	useSelectSupplier,
 	useSupplier,
 	useSuppliers,
 } from "@/data/use-suppliers";
@@ -57,6 +68,8 @@ export function ProcurementItemDrawer({ item }: ProcurementItemDrawerProps) {
 	const open = itemId != null;
 
 	const { data: supplier } = useSupplier(itemId ?? "", supplierId);
+	const [selectingSupplier, setSelectingSupplier] = useState<{ id: string; companyName: string } | null>(null);
+	const selectMutation = useSelectSupplier();
 
 	function handleTabChange(tab: ItemDrawerTab) {
 		setSearchParams(
@@ -132,6 +145,24 @@ export function ProcurementItemDrawer({ item }: ProcurementItemDrawerProps) {
 		);
 	}
 
+	function handleSelectSupplierFromTable(supplierId: string, companyName: string) {
+		setSelectingSupplier({ id: supplierId, companyName });
+	}
+
+	function handleSelectSupplierFromDrawer() {
+		if (supplier) {
+			setSelectingSupplier({ id: supplier.id, companyName: supplier.companyName });
+		}
+	}
+
+	function handleConfirmSelect() {
+		if (!selectingSupplier || !itemId) return;
+		selectMutation.mutate(
+			{ itemId, supplierId: selectingSupplier.id },
+			{ onSuccess: () => setSelectingSupplier(null) },
+		);
+	}
+
 	return (
 		<>
 			<Sheet
@@ -154,17 +185,50 @@ export function ProcurementItemDrawer({ item }: ProcurementItemDrawerProps) {
 							onTabChange={handleTabChange}
 							onSupplierClick={handleSupplierOpen}
 							onTaskClick={handleTaskOpen}
+							onSelectSupplier={handleSelectSupplierFromTable}
 						/>
 					)}
 				</SheetContent>
 			</Sheet>
-			<SupplierDetailDrawer supplier={supplier ?? null} open={supplierId != null} onClose={handleSupplierClose} />
+			<SupplierDetailDrawer
+				supplier={supplier ?? null}
+				open={supplierId != null}
+				onClose={handleSupplierClose}
+				onSelectSupplier={handleSelectSupplierFromDrawer}
+			/>
 			<TaskDrawer taskId={taskId} onClose={handleTaskClose} isMobile={isMobile} />
+			<AlertDialog
+				open={selectingSupplier != null}
+				onOpenChange={(open) => {
+					if (!open) setSelectingSupplier(null);
+				}}
+			>
+				<AlertDialogContent size="sm">
+					<AlertDialogHeader>
+						<AlertDialogTitle>Выбрать поставщика</AlertDialogTitle>
+						<AlertDialogDescription>
+							Выбрать {selectingSupplier?.companyName} текущим поставщиком?
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Отмена</AlertDialogCancel>
+						<AlertDialogAction onClick={handleConfirmSelect}>Подтвердить</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</>
 	);
 }
 
-function SuppliersTabPanel({ itemId, onSupplierClick }: { itemId: string; onSupplierClick: (id: string) => void }) {
+function SuppliersTabPanel({
+	itemId,
+	onSupplierClick,
+	onSelectSupplier,
+}: {
+	itemId: string;
+	onSupplierClick: (id: string) => void;
+	onSelectSupplier?: (supplierId: string, companyName: string) => void;
+}) {
 	const [search, setSearch] = useState("");
 	const [sort, setSort] = useState<SupplierSortState>(null);
 	const [activeStatuses, setActiveStatuses] = useState<SupplierStatus[]>([]);
@@ -252,6 +316,7 @@ function SuppliersTabPanel({ itemId, onSupplierClick }: { itemId: string; onSupp
 				onArchive={handleArchiveBulk}
 				isArchiving={archiveMutation.isPending}
 				onArchiveSupplier={handleArchiveSupplier}
+				onSelectSupplier={onSelectSupplier}
 				showArchived={showArchived}
 				onToggleArchived={() => setShowArchived((v) => !v)}
 				onDelete={handleDelete}
@@ -387,6 +452,7 @@ function ProcurementItemDrawerContent({
 	onTabChange,
 	onSupplierClick,
 	onTaskClick,
+	onSelectSupplier,
 }: {
 	itemId: string;
 	item?: ProcurementItem;
@@ -394,6 +460,7 @@ function ProcurementItemDrawerContent({
 	onTabChange: (tab: ItemDrawerTab) => void;
 	onSupplierClick: (id: string) => void;
 	onTaskClick: (id: string) => void;
+	onSelectSupplier?: (supplierId: string, companyName: string) => void;
 }) {
 	// Idempotent — only seeds if item.id is missing from the mock store
 	if (item) seedItemDetail(item);
@@ -495,7 +562,9 @@ function ProcurementItemDrawerContent({
 			</div>
 
 			<div className={`min-h-0 flex-1 overflow-y-auto ${activeTab === "suppliers" ? "pt-3" : "p-4"}`}>
-				{activeTab === "suppliers" && <SuppliersTabPanel itemId={itemId} onSupplierClick={onSupplierClick} />}
+				{activeTab === "suppliers" && (
+					<SuppliersTabPanel itemId={itemId} onSupplierClick={onSupplierClick} onSelectSupplier={onSelectSupplier} />
+				)}
 				{activeTab === "details" && <DetailsTabPanel itemId={itemId} />}
 				{activeTab === "tasks" && <TasksTabPanel itemId={itemId} onTaskClick={onTaskClick} />}
 			</div>

--- a/src/components/procurement-item-drawer.tsx
+++ b/src/components/procurement-item-drawer.tsx
@@ -14,7 +14,13 @@ import { seedItemDetail } from "@/data/item-detail-mock-data";
 import type { SupplierSortField, SupplierSortState, SupplierStatus } from "@/data/supplier-types";
 import { STATUS_ICONS } from "@/data/task-types";
 import type { ProcurementItem } from "@/data/types";
-import { useDeleteSuppliers, useInfiniteSuppliers, useSupplier, useSuppliers } from "@/data/use-suppliers";
+import {
+	useArchiveSupplier,
+	useDeleteSuppliers,
+	useInfiniteSuppliers,
+	useSupplier,
+	useSuppliers,
+} from "@/data/use-suppliers";
 import { useTaskColumns } from "@/data/use-tasks";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { cn } from "@/lib/utils";
@@ -161,18 +167,21 @@ function SuppliersTabPanel({ itemId, onSupplierClick }: { itemId: string; onSupp
 	const [sort, setSort] = useState<SupplierSortState>(null);
 	const [activeStatuses, setActiveStatuses] = useState<SupplierStatus[]>([]);
 	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+	const [showArchived, setShowArchived] = useState(false);
 
 	const filterParams = useMemo(
 		() => ({
 			search: search || undefined,
 			statuses: activeStatuses.length > 0 ? activeStatuses : undefined,
+			showArchived,
 			sort: sort?.field,
 			dir: sort?.direction,
 		}),
-		[search, activeStatuses, sort],
+		[search, activeStatuses, showArchived, sort],
 	);
 	const query = useInfiniteSuppliers(itemId, filterParams);
 	const deleteMutation = useDeleteSuppliers();
+	const archiveMutation = useArchiveSupplier();
 	const suppliers = query.data?.pages.flatMap((p) => p.suppliers) ?? [];
 
 	function handleSort(field: SupplierSortField) {
@@ -200,6 +209,17 @@ function SuppliersTabPanel({ itemId, onSupplierClick }: { itemId: string; onSupp
 		}
 	}
 
+	function handleArchiveBulk() {
+		for (const id of selectedIds) {
+			archiveMutation.mutate({ itemId, supplierId: id });
+		}
+		setSelectedIds(new Set());
+	}
+
+	function handleArchiveSupplier(supplierId: string) {
+		archiveMutation.mutate({ itemId, supplierId });
+	}
+
 	function handleDelete() {
 		const ids = [...selectedIds];
 		deleteMutation.mutate(
@@ -223,8 +243,11 @@ function SuppliersTabPanel({ itemId, onSupplierClick }: { itemId: string; onSupp
 				onStatusFilter={handleStatusFilter}
 				selectedIds={selectedIds}
 				onSelectionChange={handleSelectionChange}
-				onArchive={() => {}}
-				isArchiving={false}
+				onArchive={handleArchiveBulk}
+				isArchiving={archiveMutation.isPending}
+				onArchiveSupplier={handleArchiveSupplier}
+				showArchived={showArchived}
+				onToggleArchived={() => setShowArchived((v) => !v)}
 				onDelete={handleDelete}
 				isDeleting={deleteMutation.isPending}
 				onRowClick={onSupplierClick}

--- a/src/components/procurement-item-drawer.tsx
+++ b/src/components/procurement-item-drawer.tsx
@@ -27,7 +27,7 @@ import { STATUS_ICONS } from "@/data/task-types";
 import type { ProcurementItem } from "@/data/types";
 import { useItemDetail } from "@/data/use-item-detail";
 import {
-	useArchiveSupplier,
+	useArchiveSuppliers,
 	useDeleteSuppliers,
 	useInfiniteSuppliers,
 	useSelectSupplier,
@@ -145,14 +145,8 @@ export function ProcurementItemDrawer({ item }: ProcurementItemDrawerProps) {
 		);
 	}
 
-	function handleSelectSupplierFromTable(supplierId: string, companyName: string) {
+	function handleSelectSupplier(supplierId: string, companyName: string) {
 		setSelectingSupplier({ id: supplierId, companyName });
-	}
-
-	function handleSelectSupplierFromDrawer() {
-		if (supplier) {
-			setSelectingSupplier({ id: supplier.id, companyName: supplier.companyName });
-		}
 	}
 
 	function handleConfirmSelect() {
@@ -185,7 +179,7 @@ export function ProcurementItemDrawer({ item }: ProcurementItemDrawerProps) {
 							onTabChange={handleTabChange}
 							onSupplierClick={handleSupplierOpen}
 							onTaskClick={handleTaskOpen}
-							onSelectSupplier={handleSelectSupplierFromTable}
+							onSelectSupplier={handleSelectSupplier}
 						/>
 					)}
 				</SheetContent>
@@ -194,7 +188,7 @@ export function ProcurementItemDrawer({ item }: ProcurementItemDrawerProps) {
 				supplier={supplier ?? null}
 				open={supplierId != null}
 				onClose={handleSupplierClose}
-				onSelectSupplier={handleSelectSupplierFromDrawer}
+				onSelectSupplier={handleSelectSupplier}
 			/>
 			<TaskDrawer taskId={taskId} onClose={handleTaskClose} isMobile={isMobile} />
 			<AlertDialog
@@ -247,7 +241,7 @@ function SuppliersTabPanel({
 	);
 	const query = useInfiniteSuppliers(itemId, filterParams);
 	const deleteMutation = useDeleteSuppliers();
-	const archiveMutation = useArchiveSupplier();
+	const archiveMutation = useArchiveSuppliers();
 	const suppliers = query.data?.pages.flatMap((p) => p.suppliers) ?? [];
 
 	function handleSort(field: SupplierSortField) {
@@ -275,15 +269,9 @@ function SuppliersTabPanel({
 		}
 	}
 
-	function handleArchiveBulk() {
-		for (const id of selectedIds) {
-			archiveMutation.mutate({ itemId, supplierId: id });
-		}
-		setSelectedIds(new Set());
-	}
-
-	function handleArchiveSupplier(supplierId: string) {
-		archiveMutation.mutate({ itemId, supplierId });
+	function handleArchive(supplierIds?: string[]) {
+		const ids = supplierIds ?? [...selectedIds];
+		archiveMutation.mutate({ itemId, supplierIds: ids }, { onSuccess: () => setSelectedIds(new Set()) });
 	}
 
 	function handleDelete() {
@@ -313,9 +301,9 @@ function SuppliersTabPanel({
 				onStatusFilter={handleStatusFilter}
 				selectedIds={selectedIds}
 				onSelectionChange={handleSelectionChange}
-				onArchive={handleArchiveBulk}
+				onArchive={() => handleArchive()}
 				isArchiving={archiveMutation.isPending}
-				onArchiveSupplier={handleArchiveSupplier}
+				onArchiveSupplier={(id) => handleArchive([id])}
 				onSelectSupplier={onSelectSupplier}
 				showArchived={showArchived}
 				onToggleArchived={() => setShowArchived((v) => !v)}

--- a/src/components/procurement-item-drawer.tsx
+++ b/src/components/procurement-item-drawer.tsx
@@ -1,6 +1,7 @@
 import { Check, Clock, LoaderCircle, MessageCircle, Search, Users } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
+import { CurrentSupplierCard } from "@/components/current-supplier-card";
 import { DetailsTabPanel } from "@/components/details-tab-panel";
 import { STATUS_CONFIG } from "@/components/procurement-card";
 import { SupplierDetailDrawer } from "@/components/supplier-detail-drawer";
@@ -14,6 +15,7 @@ import { seedItemDetail } from "@/data/item-detail-mock-data";
 import type { SupplierSortField, SupplierSortState, SupplierStatus } from "@/data/supplier-types";
 import { STATUS_ICONS } from "@/data/task-types";
 import type { ProcurementItem } from "@/data/types";
+import { useItemDetail } from "@/data/use-item-detail";
 import {
 	useArchiveSupplier,
 	useDeleteSuppliers,
@@ -230,8 +232,12 @@ function SuppliersTabPanel({ itemId, onSupplierClick }: { itemId: string; onSupp
 		);
 	}
 
+	const { data: itemDetail } = useItemDetail(itemId);
+	const currentSupplier = itemDetail?.currentSupplier;
+
 	return (
 		<div data-testid="tab-panel-suppliers">
+			{currentSupplier && <CurrentSupplierCard currentSupplier={currentSupplier} />}
 			<SuppliersTable
 				suppliers={suppliers}
 				isLoading={query.isLoading}

--- a/src/components/supplier-detail-drawer.test.tsx
+++ b/src/components/supplier-detail-drawer.test.tsx
@@ -362,6 +362,31 @@ describe("SupplierDetailDrawer", () => {
 		});
 	});
 
+	describe("select supplier icon", () => {
+		test("shows select supplier icon for получено_кп status", () => {
+			renderDrawer({ onSelectSupplier: vi.fn() });
+			expect(screen.getByRole("button", { name: "Выбрать поставщика" })).toBeInTheDocument();
+		});
+
+		test("hides select supplier icon for ждем_ответа status", () => {
+			renderDrawer({ supplier: makeSupplier("s1", { status: "ждем_ответа" }), onSelectSupplier: vi.fn() });
+			expect(screen.queryByRole("button", { name: "Выбрать поставщика" })).not.toBeInTheDocument();
+		});
+
+		test("hides select supplier icon for переговоры status", () => {
+			renderDrawer({ supplier: makeSupplier("s1", { status: "переговоры" }), onSelectSupplier: vi.fn() });
+			expect(screen.queryByRole("button", { name: "Выбрать поставщика" })).not.toBeInTheDocument();
+		});
+
+		test("clicking select supplier icon calls onSelectSupplier", async () => {
+			const user = userEvent.setup();
+			const onSelectSupplier = vi.fn();
+			renderDrawer({ onSelectSupplier });
+			await user.click(screen.getByRole("button", { name: "Выбрать поставщика" }));
+			expect(onSelectSupplier).toHaveBeenCalled();
+		});
+	});
+
 	describe("ChatComposer visibility", () => {
 		test("shows composer for ждем_ответа status", () => {
 			renderDrawer({ supplier: makeSupplier("s1", { status: "ждем_ответа" }) });

--- a/src/components/supplier-detail-drawer.tsx
+++ b/src/components/supplier-detail-drawer.tsx
@@ -2,8 +2,6 @@ import {
 	Archive,
 	Bot,
 	Calculator,
-	CircleCheck,
-	CreditCard,
 	Download,
 	File,
 	FileSpreadsheet,
@@ -13,13 +11,13 @@ import {
 	MapPin,
 	Paperclip,
 	Sparkles,
-	Truck,
 	User,
 	UserCheck,
 } from "lucide-react";
 import { useCallback, useState } from "react";
 import { ChatComposer } from "@/components/chat-composer";
 import { SupplierStatusIndicator } from "@/components/supplier-status-indicator";
+import { DeferralValue, DeliveryValue } from "@/components/supplier-value-displays";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -28,53 +26,13 @@ import type { Supplier, SupplierChatMessage, SupplierDocument } from "@/data/sup
 import { COMPOSABLE_STATUSES } from "@/data/supplier-types";
 import { useSendSupplierMessage } from "@/data/use-suppliers";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import {
-	formatCurrency,
-	formatDateTime,
-	formatDeferral,
-	formatDelivery,
-	formatFileSize,
-	stripProtocol,
-} from "@/lib/format";
-
-function DeliveryValue({ cost }: { cost: number | null }) {
-	const text = formatDelivery(cost);
-	if (cost == null) {
-		return (
-			<span className="inline-flex items-center gap-1 tabular-nums">
-				<Truck className="size-3.5 text-muted-foreground" aria-hidden="true" />
-				{text}
-			</span>
-		);
-	}
-	if (cost === 0) {
-		return (
-			<span className="inline-flex items-center gap-1 tabular-nums">
-				<CircleCheck className="size-3.5 text-muted-foreground" aria-hidden="true" />
-				{text}
-			</span>
-		);
-	}
-	return <span className="tabular-nums">{text}</span>;
-}
-
-function DeferralValue({ days }: { days: number }) {
-	if (days === 0) {
-		return (
-			<span className="inline-flex items-center gap-1">
-				<CreditCard className="size-3.5 text-muted-foreground" aria-hidden="true" />
-				{formatDeferral(days)}
-			</span>
-		);
-	}
-	return <span>{formatDeferral(days)}</span>;
-}
+import { formatCurrency, formatDateTime, formatFileSize, stripProtocol } from "@/lib/format";
 
 interface SupplierDetailDrawerProps {
 	supplier: Supplier | null;
 	open: boolean;
 	onClose: () => void;
-	onSelectSupplier?: () => void;
+	onSelectSupplier?: (supplierId: string, companyName: string) => void;
 }
 
 function DocIcon({ type }: { type: string }) {
@@ -284,7 +242,7 @@ function SupplierDrawerContent({
 }: {
 	supplier: Supplier;
 	isMobile: boolean;
-	onSelectSupplier?: () => void;
+	onSelectSupplier?: (supplierId: string, companyName: string) => void;
 }) {
 	const [mobileTab, setMobileTab] = useState<MobileTab>("info");
 	const sendMutation = useSendSupplierMessage(supplier.itemId, supplier.id);
@@ -304,7 +262,7 @@ function SupplierDrawerContent({
 							size="icon-sm"
 							className="absolute top-3 right-[5.25rem]"
 							aria-label="Выбрать поставщика"
-							onClick={onSelectSupplier}
+							onClick={() => onSelectSupplier?.(supplier.id, supplier.companyName)}
 						>
 							<UserCheck aria-hidden="true" />
 						</Button>

--- a/src/components/supplier-detail-drawer.tsx
+++ b/src/components/supplier-detail-drawer.tsx
@@ -15,6 +15,7 @@ import {
 	Sparkles,
 	Truck,
 	User,
+	UserCheck,
 } from "lucide-react";
 import { useCallback, useState } from "react";
 import { ChatComposer } from "@/components/chat-composer";
@@ -73,6 +74,7 @@ interface SupplierDetailDrawerProps {
 	supplier: Supplier | null;
 	open: boolean;
 	onClose: () => void;
+	onSelectSupplier?: () => void;
 }
 
 function DocIcon({ type }: { type: string }) {
@@ -275,7 +277,15 @@ function EmailContent({
 	);
 }
 
-function SupplierDrawerContent({ supplier, isMobile }: { supplier: Supplier; isMobile: boolean }) {
+function SupplierDrawerContent({
+	supplier,
+	isMobile,
+	onSelectSupplier,
+}: {
+	supplier: Supplier;
+	isMobile: boolean;
+	onSelectSupplier?: () => void;
+}) {
 	const [mobileTab, setMobileTab] = useState<MobileTab>("info");
 	const sendMutation = useSendSupplierMessage(supplier.itemId, supplier.id);
 	const scrollToLatest = useCallback((el: HTMLElement | null) => {
@@ -286,6 +296,22 @@ function SupplierDrawerContent({ supplier, isMobile }: { supplier: Supplier; isM
 
 	return (
 		<div className="flex h-full flex-col overflow-hidden">
+			{supplier.status === "получено_кп" && onSelectSupplier && (
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon-sm"
+							className="absolute top-3 right-[5.25rem]"
+							aria-label="Выбрать поставщика"
+							onClick={onSelectSupplier}
+						>
+							<UserCheck aria-hidden="true" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Выбрать поставщика</TooltipContent>
+				</Tooltip>
+			)}
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<Button variant="ghost" size="icon-sm" className="absolute top-3 right-12" aria-label="Архивировать">
@@ -374,7 +400,7 @@ function SupplierDrawerContent({ supplier, isMobile }: { supplier: Supplier; isM
 	);
 }
 
-export function SupplierDetailDrawer({ supplier, open, onClose }: SupplierDetailDrawerProps) {
+export function SupplierDetailDrawer({ supplier, open, onClose, onSelectSupplier }: SupplierDetailDrawerProps) {
 	const isMobile = useIsMobile();
 
 	return (
@@ -385,7 +411,14 @@ export function SupplierDetailDrawer({ supplier, open, onClose }: SupplierDetail
 			}}
 		>
 			<SheetContent side={isMobile ? "bottom" : "right"} size={isMobile ? "full" : "xl"}>
-				{supplier && <SupplierDrawerContent key={supplier.id} supplier={supplier} isMobile={isMobile} />}
+				{supplier && (
+					<SupplierDrawerContent
+						key={supplier.id}
+						supplier={supplier}
+						isMobile={isMobile}
+						onSelectSupplier={onSelectSupplier}
+					/>
+				)}
 			</SheetContent>
 		</Sheet>
 	);

--- a/src/components/supplier-value-displays.tsx
+++ b/src/components/supplier-value-displays.tsx
@@ -1,0 +1,35 @@
+import { CircleCheck, CreditCard, Truck } from "lucide-react";
+import { formatDeferral, formatDelivery } from "@/lib/format";
+
+export function DeliveryValue({ cost }: { cost: number | null }) {
+	const text = formatDelivery(cost);
+	if (cost == null) {
+		return (
+			<span className="inline-flex items-center gap-1 tabular-nums">
+				<Truck className="size-3.5 text-muted-foreground" aria-hidden="true" />
+				{text}
+			</span>
+		);
+	}
+	if (cost === 0) {
+		return (
+			<span className="inline-flex items-center gap-1 tabular-nums">
+				<CircleCheck className="size-3.5 text-muted-foreground" aria-hidden="true" />
+				{text}
+			</span>
+		);
+	}
+	return <span className="tabular-nums">{text}</span>;
+}
+
+export function DeferralValue({ days }: { days: number }) {
+	if (days === 0) {
+		return (
+			<span className="inline-flex items-center gap-1">
+				<CreditCard className="size-3.5 text-muted-foreground" aria-hidden="true" />
+				{formatDeferral(days)}
+			</span>
+		);
+	}
+	return <span>{formatDeferral(days)}</span>;
+}

--- a/src/components/suppliers-table.test.tsx
+++ b/src/components/suppliers-table.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -67,6 +67,9 @@ function renderTable(props: Partial<React.ComponentProps<typeof SuppliersTable>>
 		onSelectionChange: vi.fn(),
 		onArchive: vi.fn(),
 		isArchiving: false,
+		onArchiveSupplier: vi.fn(),
+		showArchived: false,
+		onToggleArchived: vi.fn(),
 		onDelete: vi.fn(),
 		isDeleting: false,
 	};
@@ -431,5 +434,48 @@ describe("SuppliersTable mobile cards", () => {
 	test("renders search input on mobile", () => {
 		renderTable();
 		expect(screen.getByPlaceholderText("Поиск…")).toBeInTheDocument();
+	});
+});
+
+describe("SuppliersTable context menu", () => {
+	test("right-clicking a row opens context menu with Архивировать", () => {
+		renderTable();
+		const rows = screen.getAllByRole("row");
+		fireEvent.contextMenu(rows[1]);
+		expect(screen.getByText("Архивировать")).toBeInTheDocument();
+	});
+
+	test("clicking Архивировать calls onArchiveSupplier with supplier id", () => {
+		const onArchiveSupplier = vi.fn();
+		renderTable({ onArchiveSupplier });
+		const rows = screen.getAllByRole("row");
+		fireEvent.contextMenu(rows[1]);
+		fireEvent.click(screen.getByText("Архивировать"));
+		expect(onArchiveSupplier).toHaveBeenCalledWith("s1");
+	});
+});
+
+describe("SuppliersTable archive filter toggle", () => {
+	test("archive toggle button is present in toolbar", () => {
+		renderTable();
+		expect(screen.getByRole("button", { name: "Архив" })).toBeInTheDocument();
+	});
+
+	test("archive toggle shows pressed state when showArchived is true", () => {
+		renderTable({ showArchived: true });
+		expect(screen.getByRole("button", { name: "Архив" })).toHaveAttribute("aria-pressed", "true");
+	});
+
+	test("archive toggle shows unpressed state when showArchived is false", () => {
+		renderTable({ showArchived: false });
+		expect(screen.getByRole("button", { name: "Архив" })).toHaveAttribute("aria-pressed", "false");
+	});
+
+	test("clicking archive toggle calls onToggleArchived", async () => {
+		const user = userEvent.setup();
+		const onToggleArchived = vi.fn();
+		renderTable({ onToggleArchived });
+		await user.click(screen.getByRole("button", { name: "Архив" }));
+		expect(onToggleArchived).toHaveBeenCalled();
 	});
 });

--- a/src/components/suppliers-table.test.tsx
+++ b/src/components/suppliers-table.test.tsx
@@ -453,6 +453,33 @@ describe("SuppliersTable context menu", () => {
 		fireEvent.click(screen.getByText("Архивировать"));
 		expect(onArchiveSupplier).toHaveBeenCalledWith("s1");
 	});
+
+	test("context menu shows Выбрать поставщика for получено_кп supplier", () => {
+		const onSelectSupplier = vi.fn();
+		renderTable({ onSelectSupplier });
+		const rows = screen.getAllByRole("row");
+		// s1 is получено_кп
+		fireEvent.contextMenu(rows[1]);
+		expect(screen.getByText("Выбрать поставщика")).toBeInTheDocument();
+	});
+
+	test("context menu hides Выбрать поставщика for non-получено_кп supplier", () => {
+		const onSelectSupplier = vi.fn();
+		renderTable({ onSelectSupplier });
+		const rows = screen.getAllByRole("row");
+		// s2 is ждем_ответа
+		fireEvent.contextMenu(rows[2]);
+		expect(screen.queryByText("Выбрать поставщика")).not.toBeInTheDocument();
+	});
+
+	test("clicking Выбрать поставщика calls onSelectSupplier with id and company name", () => {
+		const onSelectSupplier = vi.fn();
+		renderTable({ onSelectSupplier });
+		const rows = screen.getAllByRole("row");
+		fireEvent.contextMenu(rows[1]);
+		fireEvent.click(screen.getByText("Выбрать поставщика"));
+		expect(onSelectSupplier).toHaveBeenCalledWith("s1", "ООО «Альфа»");
+	});
 });
 
 describe("SuppliersTable archive filter toggle", () => {

--- a/src/components/suppliers-table.tsx
+++ b/src/components/suppliers-table.tsx
@@ -11,6 +11,7 @@ import {
 	Search,
 	Trash2,
 	Truck,
+	UserCheck,
 } from "lucide-react";
 import { useRef } from "react";
 import { SupplierStatusIndicator } from "@/components/supplier-status-indicator";
@@ -55,6 +56,7 @@ interface SuppliersTableProps {
 	onArchive: () => void;
 	isArchiving: boolean;
 	onArchiveSupplier: (supplierId: string) => void;
+	onSelectSupplier?: (supplierId: string, companyName: string) => void;
 	showArchived: boolean;
 	onToggleArchived: () => void;
 	onDelete: () => void;
@@ -128,6 +130,7 @@ export function SuppliersTable({
 	onArchive,
 	isArchiving,
 	onArchiveSupplier,
+	onSelectSupplier,
 	showArchived,
 	onToggleArchived,
 	onDelete,
@@ -444,6 +447,12 @@ export function SuppliersTable({
 									</TableRow>
 								</ContextMenuTrigger>
 								<ContextMenuContent>
+									{supplier.status === "получено_кп" && onSelectSupplier && (
+										<ContextMenuItem onSelect={() => onSelectSupplier(supplier.id, supplier.companyName)}>
+											<UserCheck className="size-3.5" />
+											Выбрать поставщика
+										</ContextMenuItem>
+									)}
 									<ContextMenuItem onSelect={() => onArchiveSupplier(supplier.id)}>
 										<Archive className="size-3.5" />
 										Архивировать

--- a/src/components/suppliers-table.tsx
+++ b/src/components/suppliers-table.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -53,6 +54,9 @@ interface SuppliersTableProps {
 	onSelectionChange: (idOrAll: string) => void;
 	onArchive: () => void;
 	isArchiving: boolean;
+	onArchiveSupplier: (supplierId: string) => void;
+	showArchived: boolean;
+	onToggleArchived: () => void;
 	onDelete: () => void;
 	isDeleting: boolean;
 	onRowClick?: (supplierId: string) => void;
@@ -123,6 +127,9 @@ export function SuppliersTable({
 	onSelectionChange,
 	onArchive,
 	isArchiving,
+	onArchiveSupplier,
+	showArchived,
+	onToggleArchived,
 	onDelete,
 	isDeleting,
 	onRowClick,
@@ -247,7 +254,15 @@ export function SuppliersTable({
 			</Tooltip>
 			<Tooltip>
 				<TooltipTrigger asChild>
-					<Button type="button" variant="ghost" size="icon-sm" aria-label="Архив">
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon-sm"
+						aria-label="Архив"
+						aria-pressed={showArchived}
+						onClick={onToggleArchived}
+						className={showArchived ? "bg-muted" : ""}
+					>
 						<Archive aria-hidden="true" />
 					</Button>
 				</TooltipTrigger>
@@ -389,43 +404,52 @@ export function SuppliersTable({
 						</TableRow>
 					) : (
 						suppliers.map((supplier) => (
-							<TableRow
-								key={supplier.id}
-								className={onRowClick ? "cursor-pointer hover:bg-muted/50" : ""}
-								onClick={() => onRowClick?.(supplier.id)}
-							>
-								<TableCell onClick={(e) => e.stopPropagation()}>
-									<Checkbox
-										checked={selectedIds.has(supplier.id)}
-										onCheckedChange={() => onSelectionChange(supplier.id)}
-										aria-label={`Выбрать ${supplier.companyName}`}
-									/>
-								</TableCell>
-								<TableCell>
-									<div className="flex flex-col gap-1">
-										<span className="font-medium">{supplier.companyName}</span>
-										<SupplierStatusIndicator status={supplier.status} className="text-xs" />
-									</div>
-								</TableCell>
-								<TableCell onClick={(e) => e.stopPropagation()}>
-									<a
-										href={supplier.website.startsWith("http") ? supplier.website : `https://${supplier.website}`}
-										target="_blank"
-										rel="noopener noreferrer"
-										className="text-foreground underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+							<ContextMenu key={supplier.id}>
+								<ContextMenuTrigger asChild>
+									<TableRow
+										className={onRowClick ? "cursor-pointer hover:bg-muted/50" : ""}
+										onClick={() => onRowClick?.(supplier.id)}
 									>
-										{stripProtocol(supplier.website)}
-									</a>
-								</TableCell>
-								<TableCell>
-									<DeliveryValue cost={supplier.deliveryCost} />
-								</TableCell>
-								<TableCell>
-									<DeferralValue days={supplier.deferralDays} />
-								</TableCell>
-								<TableCell className="text-right tabular-nums">{formatCurrency(supplier.pricePerUnit)}</TableCell>
-								<TableCell className="text-right tabular-nums">{formatCurrency(supplier.tco)}</TableCell>
-							</TableRow>
+										<TableCell onClick={(e) => e.stopPropagation()}>
+											<Checkbox
+												checked={selectedIds.has(supplier.id)}
+												onCheckedChange={() => onSelectionChange(supplier.id)}
+												aria-label={`Выбрать ${supplier.companyName}`}
+											/>
+										</TableCell>
+										<TableCell>
+											<div className="flex flex-col gap-1">
+												<span className="font-medium">{supplier.companyName}</span>
+												<SupplierStatusIndicator status={supplier.status} className="text-xs" />
+											</div>
+										</TableCell>
+										<TableCell onClick={(e) => e.stopPropagation()}>
+											<a
+												href={supplier.website.startsWith("http") ? supplier.website : `https://${supplier.website}`}
+												target="_blank"
+												rel="noopener noreferrer"
+												className="text-foreground underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+											>
+												{stripProtocol(supplier.website)}
+											</a>
+										</TableCell>
+										<TableCell>
+											<DeliveryValue cost={supplier.deliveryCost} />
+										</TableCell>
+										<TableCell>
+											<DeferralValue days={supplier.deferralDays} />
+										</TableCell>
+										<TableCell className="text-right tabular-nums">{formatCurrency(supplier.pricePerUnit)}</TableCell>
+										<TableCell className="text-right tabular-nums">{formatCurrency(supplier.tco)}</TableCell>
+									</TableRow>
+								</ContextMenuTrigger>
+								<ContextMenuContent>
+									<ContextMenuItem onSelect={() => onArchiveSupplier(supplier.id)}>
+										<Archive className="size-3.5" />
+										Архивировать
+									</ContextMenuItem>
+								</ContextMenuContent>
+							</ContextMenu>
 						))
 					)}
 				</TableBody>

--- a/src/components/suppliers-table.tsx
+++ b/src/components/suppliers-table.tsx
@@ -3,18 +3,16 @@ import {
 	ArrowDown,
 	ArrowUp,
 	ArrowUpDown,
-	CircleCheck,
-	CreditCard,
 	Download,
 	ListFilter,
 	LoaderCircle,
 	Search,
 	Trash2,
-	Truck,
 	UserCheck,
 } from "lucide-react";
 import { useRef } from "react";
 import { SupplierStatusIndicator } from "@/components/supplier-status-indicator";
+import { DeferralValue, DeliveryValue } from "@/components/supplier-value-displays";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -39,7 +37,7 @@ import { SUPPLIER_STATUS_LABELS, SUPPLIER_STATUSES } from "@/data/supplier-types
 import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useMountEffect } from "@/hooks/use-mount-effect";
-import { formatCurrency, formatDeferral, formatDelivery, stripProtocol } from "@/lib/format";
+import { formatCurrency, stripProtocol } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 interface SuppliersTableProps {
@@ -72,39 +70,6 @@ const SORTABLE_COLUMNS: { label: string; field: SupplierSortField }[] = [
 	{ label: "ЦЕНА/ЕД.", field: "pricePerUnit" },
 	{ label: "TCO", field: "tco" },
 ];
-
-function DeliveryValue({ cost }: { cost: number | null }) {
-	const text = formatDelivery(cost);
-	if (cost == null) {
-		return (
-			<span className="inline-flex items-center gap-1">
-				<Truck className="size-3.5 text-muted-foreground" aria-hidden="true" />
-				{text}
-			</span>
-		);
-	}
-	if (cost === 0) {
-		return (
-			<span className="inline-flex items-center gap-1">
-				<CircleCheck className="size-3.5 text-muted-foreground" aria-hidden="true" />
-				{text}
-			</span>
-		);
-	}
-	return <span className="tabular-nums">{text}</span>;
-}
-
-function DeferralValue({ days }: { days: number }) {
-	if (days === 0) {
-		return (
-			<span className="inline-flex items-center gap-1">
-				<CreditCard className="size-3.5 text-muted-foreground" aria-hidden="true" />
-				{formatDeferral(days)}
-			</span>
-		);
-	}
-	return <span>{formatDeferral(days)}</span>;
-}
 
 const FILTER_BTN =
 	"rounded-md px-3 py-1.5 text-left text-sm transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";

--- a/src/data/item-detail-mock-data.ts
+++ b/src/data/item-detail-mock-data.ts
@@ -1,4 +1,4 @@
-import type { ProcurementItem } from "./types";
+import type { CurrentSupplier, ProcurementItem } from "./types";
 
 // --- Default mock item data ---
 
@@ -87,6 +87,13 @@ function simulateDelay(): Promise<void> {
 export async function getItemDetail(id: string): Promise<ProcurementItem | null> {
 	await simulateDelay();
 	return store.get(id) ?? null;
+}
+
+/** Directly update item's currentSupplier in the mock store (no delay). */
+export function setItemCurrentSupplier(itemId: string, currentSupplier: CurrentSupplier): void {
+	const item = store.get(itemId);
+	if (!item) throw new Error(`Item ${itemId} not found`);
+	store.set(itemId, { ...item, currentSupplier });
 }
 
 export async function updateItemDetail(

--- a/src/data/item-detail-mock-data.ts
+++ b/src/data/item-detail-mock-data.ts
@@ -25,6 +25,13 @@ const MOCK_ITEMS: Record<string, ProcurementItem> = {
 		analoguesAllowed: true,
 		additionalInfo: "Требуется сертификат соответствия ГОСТ",
 		priceMonitoringPeriod: "quarter",
+		currentSupplier: {
+			companyName: "МеталлТрейд",
+			deliveryCost: 0,
+			deferralDays: 30,
+			pricePerUnit: 4500,
+			tco: 5400000,
+		},
 	},
 	"item-2": {
 		id: "item-2",

--- a/src/data/item-detail-mock-data.ts
+++ b/src/data/item-detail-mock-data.ts
@@ -92,7 +92,7 @@ export async function getItemDetail(id: string): Promise<ProcurementItem | null>
 /** Directly update item's currentSupplier in the mock store (no delay). */
 export function setItemCurrentSupplier(itemId: string, currentSupplier: CurrentSupplier): void {
 	const item = store.get(itemId);
-	if (!item) throw new Error(`Item ${itemId} not found`);
+	if (!item) return;
 	store.set(itemId, { ...item, currentSupplier });
 }
 

--- a/src/data/supplier-mock-data.ts
+++ b/src/data/supplier-mock-data.ts
@@ -166,6 +166,7 @@ function createSuppliersForItem(itemId: string): Supplier[] {
 			itemId,
 			companyName: COMPANY_NAMES[idx % COMPANY_NAMES.length],
 			status,
+			archived: false,
 			email: `info@${WEBSITES[idx % WEBSITES.length]}`,
 			website: `https://${WEBSITES[idx % WEBSITES.length]}`,
 			address: ADDRESSES[idx % ADDRESSES.length],
@@ -224,6 +225,10 @@ function simulateDelay(): Promise<void> {
 
 function applySupplierFilters(suppliers: Supplier[], params?: SupplierFilterParams): Supplier[] {
 	let result = suppliers;
+
+	if (!params?.showArchived) {
+		result = result.filter((s) => !s.archived);
+	}
 
 	if (params?.search) {
 		const q = params.search.toLowerCase();
@@ -301,6 +306,14 @@ export async function deleteSuppliers(itemId: string, supplierIds: string[]): Pr
 	const idsToDelete = new Set(supplierIds);
 	const remaining = suppliers.filter((s) => !idsToDelete.has(s.id));
 	store.set(itemId, remaining);
+}
+
+export async function archiveSupplier(itemId: string, supplierId: string): Promise<void> {
+	await simulateDelay();
+	const suppliers = getSuppliersForItem(itemId);
+	const supplier = suppliers.find((s) => s.id === supplierId);
+	if (!supplier) throw new Error("Supplier not found");
+	supplier.archived = true;
 }
 
 export async function sendSupplierMessage(

--- a/src/data/supplier-mock-data.ts
+++ b/src/data/supplier-mock-data.ts
@@ -309,12 +309,14 @@ export async function deleteSuppliers(itemId: string, supplierIds: string[]): Pr
 	store.set(itemId, remaining);
 }
 
-export async function archiveSupplier(itemId: string, supplierId: string): Promise<void> {
+export async function archiveSuppliers(itemId: string, supplierIds: string[]): Promise<void> {
 	await simulateDelay();
 	const suppliers = getSuppliersForItem(itemId);
-	const supplier = suppliers.find((s) => s.id === supplierId);
-	if (!supplier) throw new Error("Supplier not found");
-	supplier.archived = true;
+	const idsToArchive = new Set(supplierIds);
+	store.set(
+		itemId,
+		suppliers.map((s) => (idsToArchive.has(s.id) ? { ...s, archived: true } : s)),
+	);
 }
 
 export async function selectSupplier(itemId: string, supplierId: string): Promise<void> {

--- a/src/data/supplier-mock-data.ts
+++ b/src/data/supplier-mock-data.ts
@@ -1,3 +1,4 @@
+import { setItemCurrentSupplier } from "./item-detail-mock-data";
 import type {
 	Supplier,
 	SupplierChatMessage,
@@ -314,6 +315,20 @@ export async function archiveSupplier(itemId: string, supplierId: string): Promi
 	const supplier = suppliers.find((s) => s.id === supplierId);
 	if (!supplier) throw new Error("Supplier not found");
 	supplier.archived = true;
+}
+
+export async function selectSupplier(itemId: string, supplierId: string): Promise<void> {
+	await simulateDelay();
+	const suppliers = getSuppliersForItem(itemId);
+	const supplier = suppliers.find((s) => s.id === supplierId);
+	if (!supplier) throw new Error("Supplier not found");
+	setItemCurrentSupplier(itemId, {
+		companyName: supplier.companyName,
+		deliveryCost: supplier.deliveryCost,
+		deferralDays: supplier.deferralDays,
+		pricePerUnit: supplier.pricePerUnit,
+		tco: supplier.tco,
+	});
 }
 
 export async function sendSupplierMessage(

--- a/src/data/supplier-types.ts
+++ b/src/data/supplier-types.ts
@@ -67,6 +67,7 @@ export type SupplierSortState = { field: SupplierSortField; direction: "asc" | "
 export interface SupplierFilterParams {
 	search?: string;
 	statuses?: SupplierStatus[];
+	showArchived?: boolean;
 	sort?: SupplierSortField;
 	dir?: "asc" | "desc";
 	cursor?: string;
@@ -78,6 +79,7 @@ export interface Supplier {
 	itemId: string;
 	companyName: string;
 	status: SupplierStatus;
+	archived: boolean;
 	email: string;
 	website: string;
 	address: string;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -154,6 +154,7 @@ export interface NewItemInput {
 	analoguesAllowed?: boolean;
 	additionalInfo?: string;
 	priceMonitoringPeriod?: PriceMonitoringPeriod;
+	currentSupplier?: CurrentSupplier;
 }
 
 /** Annual cost in ₽ = annualQuantity × currentPrice. */

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -66,6 +66,14 @@ export const PAYMENT_TYPES = Object.keys(PAYMENT_TYPE_LABELS) as PaymentType[];
 export const PAYMENT_METHODS = Object.keys(PAYMENT_METHOD_LABELS) as PaymentMethod[];
 export const DELIVERY_TYPES = Object.keys(DELIVERY_TYPE_LABELS) as DeliveryType[];
 
+export interface CurrentSupplier {
+	companyName: string;
+	deliveryCost: number | null;
+	deferralDays: number;
+	pricePerUnit: number | null;
+	tco: number | null;
+}
+
 export interface ProcurementItem {
 	id: string;
 	name: string;
@@ -91,6 +99,7 @@ export interface ProcurementItem {
 	analoguesAllowed?: boolean;
 	additionalInfo?: string;
 	priceMonitoringPeriod?: PriceMonitoringPeriod;
+	currentSupplier?: CurrentSupplier;
 }
 
 export interface Folder {

--- a/src/data/use-suppliers.ts
+++ b/src/data/use-suppliers.ts
@@ -1,5 +1,12 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { deleteSuppliers, getAllSuppliers, getSupplier, getSuppliers, sendSupplierMessage } from "./supplier-mock-data";
+import {
+	archiveSupplier,
+	deleteSuppliers,
+	getAllSuppliers,
+	getSupplier,
+	getSuppliers,
+	sendSupplierMessage,
+} from "./supplier-mock-data";
 import type { Supplier, SupplierChatMessage, SupplierFilterParams } from "./supplier-types";
 import { filesToAttachments } from "./supplier-types";
 
@@ -26,6 +33,17 @@ export function useSupplier(itemId: string, supplierId: string | null) {
 		queryKey: ["supplier", itemId, supplierId],
 		queryFn: () => getSupplier(itemId, supplierId as string),
 		enabled: supplierId !== null,
+	});
+}
+
+export function useArchiveSupplier() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: ({ itemId, supplierId }: { itemId: string; supplierId: string }) => archiveSupplier(itemId, supplierId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["suppliers"] });
+			queryClient.invalidateQueries({ queryKey: ["suppliers-all"] });
+		},
 	});
 }
 

--- a/src/data/use-suppliers.ts
+++ b/src/data/use-suppliers.ts
@@ -5,6 +5,7 @@ import {
 	getAllSuppliers,
 	getSupplier,
 	getSuppliers,
+	selectSupplier,
 	sendSupplierMessage,
 } from "./supplier-mock-data";
 import type { Supplier, SupplierChatMessage, SupplierFilterParams } from "./supplier-types";
@@ -41,6 +42,18 @@ export function useArchiveSupplier() {
 	return useMutation({
 		mutationFn: ({ itemId, supplierId }: { itemId: string; supplierId: string }) => archiveSupplier(itemId, supplierId),
 		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["suppliers"] });
+			queryClient.invalidateQueries({ queryKey: ["suppliers-all"] });
+		},
+	});
+}
+
+export function useSelectSupplier() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: ({ itemId, supplierId }: { itemId: string; supplierId: string }) => selectSupplier(itemId, supplierId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["itemDetail"] });
 			queryClient.invalidateQueries({ queryKey: ["suppliers"] });
 			queryClient.invalidateQueries({ queryKey: ["suppliers-all"] });
 		},

--- a/src/data/use-suppliers.ts
+++ b/src/data/use-suppliers.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-	archiveSupplier,
+	archiveSuppliers,
 	deleteSuppliers,
 	getAllSuppliers,
 	getSupplier,
@@ -37,13 +37,14 @@ export function useSupplier(itemId: string, supplierId: string | null) {
 	});
 }
 
-export function useArchiveSupplier() {
+export function useArchiveSuppliers() {
 	const queryClient = useQueryClient();
 	return useMutation({
-		mutationFn: ({ itemId, supplierId }: { itemId: string; supplierId: string }) => archiveSupplier(itemId, supplierId),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["suppliers"] });
-			queryClient.invalidateQueries({ queryKey: ["suppliers-all"] });
+		mutationFn: ({ itemId, supplierIds }: { itemId: string; supplierIds: string[] }) =>
+			archiveSuppliers(itemId, supplierIds),
+		onSuccess: (_data, { itemId }) => {
+			queryClient.invalidateQueries({ queryKey: ["suppliers", itemId] });
+			queryClient.invalidateQueries({ queryKey: ["suppliers-all", itemId] });
 		},
 	});
 }
@@ -52,10 +53,10 @@ export function useSelectSupplier() {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: ({ itemId, supplierId }: { itemId: string; supplierId: string }) => selectSupplier(itemId, supplierId),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["itemDetail"] });
-			queryClient.invalidateQueries({ queryKey: ["suppliers"] });
-			queryClient.invalidateQueries({ queryKey: ["suppliers-all"] });
+		onSuccess: (_data, { itemId }) => {
+			queryClient.invalidateQueries({ queryKey: ["itemDetail", itemId] });
+			queryClient.invalidateQueries({ queryKey: ["suppliers", itemId] });
+			queryClient.invalidateQueries({ queryKey: ["suppliers-all", itemId] });
 		},
 	});
 }
@@ -65,9 +66,9 @@ export function useDeleteSuppliers() {
 	return useMutation({
 		mutationFn: ({ itemId, supplierIds }: { itemId: string; supplierIds: string[] }) =>
 			deleteSuppliers(itemId, supplierIds),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["suppliers"] });
-			queryClient.invalidateQueries({ queryKey: ["suppliers-all"] });
+		onSuccess: (_data, { itemId }) => {
+			queryClient.invalidateQueries({ queryKey: ["suppliers", itemId] });
+			queryClient.invalidateQueries({ queryKey: ["suppliers-all", itemId] });
 		},
 	});
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -127,6 +127,7 @@ export function makeSupplier(id: string, overrides: Partial<Supplier> = {}): Sup
 		itemId: "item-1",
 		companyName: `Поставщик ${id}`,
 		status: "ждем_ответа",
+		archived: false,
 		email: "info@example.ru",
 		website: "https://example.ru",
 		address: "г. Москва, ул. Тестовая, д. 1",


### PR DESCRIPTION
## Summary
- Add `CurrentSupplier` type and summary card with formatted fields (#193)
- Collapsible current supplier form section in add-positions drawer (#195)
- Select supplier flow: context menu + detail drawer icon + confirmation modal (#194)
- Archive supplier: context menu action + filter toggle (#192)
- Deduplicate `DeliveryValue`/`DeferralValue` display components, scope query invalidation (#191)

Closes #191
Closes #192
Closes #193
Closes #194
Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)