### PR TITLE
RALPH: Filters popover — Компания + Категория sections with folder CRUD (#219)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -215,7 +215,7 @@ describe("Routing", () => {
 		await user.click(within(header).getByRole("button", { name: "Меню пользователя" }));
 
 		expect(screen.getByRole("menuitem", { name: "Мой профиль" })).toBeInTheDocument();
-		expect(screen.getByRole("menuitem", { name: "Компании" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: /Сменить тему/ })).toBeInTheDocument();
 		expect(screen.getByRole("menuitem", { name: "Выйти" })).toBeInTheDocument();
 	});
 

--- a/src/components/app-layout.test.tsx
+++ b/src/components/app-layout.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { _resetWorkspaceStore, _setUserSettings } from "@/data/workspace-mock-data";
-import { createTestQueryClient, makeSettings } from "@/test-utils";
+import { createTestQueryClient, makeSettings, TooltipWrapper } from "@/test-utils";
 import { AppLayout } from "./app-layout";
 
 beforeEach(() => {
@@ -19,14 +19,16 @@ function renderLayout(initialEntry = "/procurement") {
 	const queryClient = createTestQueryClient();
 	return render(
 		<QueryClientProvider client={queryClient}>
-			<MemoryRouter initialEntries={[initialEntry]}>
-				<Routes>
-					<Route element={<AppLayout />}>
-						<Route path="/procurement" element={<div>procurement-content</div>} />
-						<Route path="/tasks" element={<div>tasks-content</div>} />
-					</Route>
-				</Routes>
-			</MemoryRouter>
+			<TooltipWrapper>
+				<MemoryRouter initialEntries={[initialEntry]}>
+					<Routes>
+						<Route element={<AppLayout />}>
+							<Route path="/procurement" element={<div>procurement-content</div>} />
+							<Route path="/tasks" element={<div>tasks-content</div>} />
+						</Route>
+					</Routes>
+				</MemoryRouter>
+			</TooltipWrapper>
 		</QueryClientProvider>,
 	);
 }
@@ -59,5 +61,17 @@ describe("AppLayout — global header", () => {
 	test("renders child route content", () => {
 		renderLayout();
 		expect(screen.getByText("procurement-content")).toBeInTheDocument();
+	});
+});
+
+describe("AppLayout — top-level navigation", () => {
+	test("mounts AppRail", () => {
+		renderLayout();
+		expect(screen.getByTestId("app-rail")).toBeInTheDocument();
+	});
+
+	test("mounts BottomTabBar", () => {
+		renderLayout();
+		expect(screen.getByTestId("bottom-tab-bar")).toBeInTheDocument();
 	});
 });

--- a/src/components/app-layout.test.tsx
+++ b/src/components/app-layout.test.tsx
@@ -56,12 +56,6 @@ describe("AppLayout — global header", () => {
 		expect(screen.getByRole("button", { name: "Меню пользователя" })).toBeInTheDocument();
 	});
 
-	test("renders toolbar slot in header for desktop", () => {
-		renderLayout();
-		const header = screen.getByTestId("global-header");
-		expect(header.querySelector('[data-testid="toolbar-slot"]')).toBeInTheDocument();
-	});
-
 	test("renders child route content", () => {
 		renderLayout();
 		expect(screen.getByText("procurement-content")).toBeInTheDocument();

--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -1,4 +1,6 @@
 import { Link, Outlet } from "react-router";
+import { AppRail } from "@/components/app-rail";
+import { BottomTabBar } from "@/components/bottom-tab-bar";
 import { LogoWordmark } from "@/components/logo-wordmark";
 import { UserAvatarMenu } from "@/components/user-avatar-menu";
 
@@ -19,9 +21,13 @@ export function AppLayout() {
 				</div>
 				<UserAvatarMenu />
 			</header>
-			<div className="flex min-h-0 flex-1 flex-col">
-				<Outlet />
+			<div className="flex min-h-0 flex-1">
+				<AppRail />
+				<div className="flex min-w-0 flex-1 flex-col">
+					<Outlet />
+				</div>
 			</div>
+			<BottomTabBar />
 		</div>
 	);
 }

--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -1,39 +1,27 @@
-import { createContext, useContext, useState } from "react";
 import { Link, Outlet } from "react-router";
 import { LogoWordmark } from "@/components/logo-wordmark";
 import { UserAvatarMenu } from "@/components/user-avatar-menu";
 
-const ToolbarPortalContext = createContext<HTMLDivElement | null>(null);
-
-export function useToolbarPortal() {
-	return useContext(ToolbarPortalContext);
-}
-
 export function AppLayout() {
-	const [toolbarEl, setToolbarEl] = useState<HTMLDivElement | null>(null);
-
 	return (
-		<ToolbarPortalContext.Provider value={toolbarEl}>
-			<div className="flex h-svh w-full flex-col" data-testid="app-layout">
-				<header
-					className="sticky top-0 z-30 flex shrink-0 items-center justify-between gap-3 border-b border-border bg-background px-3 py-1.5"
-					data-testid="global-header"
-				>
-					<div className="flex shrink-0 items-center gap-2">
-						<Link to="/procurement" aria-label="На главную">
-							<LogoWordmark className="h-4 w-auto" />
-						</Link>
-						<span className="hidden -translate-y-px select-none items-center rounded-full px-1.5 py-0.5 text-[0.5625rem] font-medium tracking-wide text-muted-foreground/70 ring-1 ring-border md:inline-flex">
-							Beta
-						</span>
-					</div>
-					<div ref={setToolbarEl} className="hidden min-w-0 flex-1 items-center md:flex" data-testid="toolbar-slot" />
-					<UserAvatarMenu />
-				</header>
-				<div className="flex min-h-0 flex-1 flex-col">
-					<Outlet />
+		<div className="flex h-svh w-full flex-col" data-testid="app-layout">
+			<header
+				className="sticky top-0 z-30 flex shrink-0 items-center justify-between gap-3 border-b border-border bg-background px-3 py-1.5"
+				data-testid="global-header"
+			>
+				<div className="flex shrink-0 items-center gap-2">
+					<Link to="/procurement" aria-label="На главную">
+						<LogoWordmark className="h-4 w-auto" />
+					</Link>
+					<span className="hidden -translate-y-px select-none items-center rounded-full px-1.5 py-0.5 text-[0.5625rem] font-medium tracking-wide text-muted-foreground/70 ring-1 ring-border md:inline-flex">
+						Beta
+					</span>
 				</div>
+				<UserAvatarMenu />
+			</header>
+			<div className="flex min-h-0 flex-1 flex-col">
+				<Outlet />
 			</div>
-		</ToolbarPortalContext.Provider>
+		</div>
 	);
 }

--- a/src/components/app-rail.test.tsx
+++ b/src/components/app-rail.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, test } from "vitest";
+import { TooltipWrapper } from "@/test-utils";
+import { AppRail } from "./app-rail";
+
+function renderRail(initialPath = "/procurement") {
+	return render(
+		<TooltipWrapper>
+			<MemoryRouter initialEntries={[initialPath]}>
+				<Routes>
+					<Route path="*" element={<AppRail />} />
+				</Routes>
+			</MemoryRouter>
+		</TooltipWrapper>,
+	);
+}
+
+describe("AppRail items", () => {
+	test("renders Закупки, Задачи, and Настройки with aria-labels", () => {
+		renderRail();
+		expect(screen.getByRole("link", { name: "Закупки" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Задачи" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Настройки" })).toBeInTheDocument();
+	});
+
+	test("items link to /procurement, /tasks, and /settings", () => {
+		renderRail();
+		expect(screen.getByRole("link", { name: "Закупки" })).toHaveAttribute("href", "/procurement");
+		expect(screen.getByRole("link", { name: "Задачи" })).toHaveAttribute("href", "/tasks");
+		expect(screen.getByRole("link", { name: "Настройки" })).toHaveAttribute("href", "/settings");
+	});
+
+	test("nav has aria-label", () => {
+		renderRail();
+		expect(screen.getByRole("navigation", { name: "Основная навигация" })).toBeInTheDocument();
+	});
+});
+
+describe("AppRail active state", () => {
+	test("marks Закупки active at /procurement", () => {
+		renderRail("/procurement");
+		expect(screen.getByRole("link", { name: "Закупки" })).toHaveAttribute("aria-current", "page");
+		expect(screen.getByRole("link", { name: "Задачи" })).not.toHaveAttribute("aria-current");
+	});
+
+	test("marks Задачи active at /tasks", () => {
+		renderRail("/tasks");
+		expect(screen.getByRole("link", { name: "Задачи" })).toHaveAttribute("aria-current", "page");
+	});
+
+	test("marks Настройки active at /settings", () => {
+		renderRail("/settings");
+		expect(screen.getByRole("link", { name: "Настройки" })).toHaveAttribute("aria-current", "page");
+	});
+
+	test("marks Настройки active for deep settings routes (/settings/profile)", () => {
+		renderRail("/settings/profile");
+		expect(screen.getByRole("link", { name: "Настройки" })).toHaveAttribute("aria-current", "page");
+	});
+
+	test("marks Закупки active when query params are present", () => {
+		renderRail("/procurement?folder=archive");
+		expect(screen.getByRole("link", { name: "Закупки" })).toHaveAttribute("aria-current", "page");
+	});
+});
+
+describe("AppRail visibility", () => {
+	test("container has desktop-only visibility classes (hidden on mobile)", () => {
+		renderRail();
+		const rail = screen.getByTestId("app-rail");
+		expect(rail.className).toContain("hidden");
+		expect(rail.className).toContain("md:flex");
+	});
+});
+
+describe("AppRail navigation", () => {
+	test("clicking an item navigates", async () => {
+		render(
+			<TooltipWrapper>
+				<MemoryRouter initialEntries={["/procurement"]}>
+					<AppRail />
+					<Routes>
+						<Route path="/procurement" element={<div>procurement-page</div>} />
+						<Route path="/tasks" element={<div>tasks-page</div>} />
+					</Routes>
+				</MemoryRouter>
+			</TooltipWrapper>,
+		);
+		await userEvent.setup().click(screen.getByRole("link", { name: "Задачи" }));
+		expect(screen.getByText("tasks-page")).toBeInTheDocument();
+	});
+});

--- a/src/components/app-rail.tsx
+++ b/src/components/app-rail.tsx
@@ -1,0 +1,45 @@
+import { ListTodo, Package, Settings } from "lucide-react";
+import { Link, useLocation } from "react-router";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+const RAIL_ITEMS = [
+	{ path: "/procurement", label: "Закупки", icon: Package },
+	{ path: "/tasks", label: "Задачи", icon: ListTodo },
+	{ path: "/settings", label: "Настройки", icon: Settings },
+] as const;
+
+export function AppRail() {
+	const { pathname } = useLocation();
+	return (
+		<nav
+			aria-label="Основная навигация"
+			className="hidden w-12 shrink-0 flex-col items-center gap-1 border-r border-sidebar-border bg-sidebar py-2 md:flex"
+			data-testid="app-rail"
+		>
+			{RAIL_ITEMS.map(({ path, label, icon: Icon }) => {
+				const active = pathname.startsWith(path);
+				return (
+					<Tooltip key={path}>
+						<TooltipTrigger asChild>
+							<Link
+								to={path}
+								aria-label={label}
+								aria-current={active ? "page" : undefined}
+								className={cn(
+									"flex size-9 items-center justify-center rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+									active
+										? "bg-sidebar-accent text-sidebar-accent-foreground"
+										: "text-sidebar-foreground hover:bg-sidebar-accent/50",
+								)}
+							>
+								<Icon className="size-5" aria-hidden="true" />
+							</Link>
+						</TooltipTrigger>
+						<TooltipContent side="right">{label}</TooltipContent>
+					</Tooltip>
+				);
+			})}
+		</nav>
+	);
+}

--- a/src/components/bottom-tab-bar.test.tsx
+++ b/src/components/bottom-tab-bar.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, test } from "vitest";
+import { BottomTabBar } from "./bottom-tab-bar";
+
+function renderBar(initialPath = "/procurement") {
+	return render(
+		<MemoryRouter initialEntries={[initialPath]}>
+			<Routes>
+				<Route path="*" element={<BottomTabBar />} />
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+describe("BottomTabBar items", () => {
+	test("renders Закупки, Задачи, and Настройки with aria-labels", () => {
+		renderBar();
+		expect(screen.getByRole("link", { name: "Закупки" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Задачи" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Настройки" })).toBeInTheDocument();
+	});
+
+	test("items link to /procurement, /tasks, and /settings", () => {
+		renderBar();
+		expect(screen.getByRole("link", { name: "Закупки" })).toHaveAttribute("href", "/procurement");
+		expect(screen.getByRole("link", { name: "Задачи" })).toHaveAttribute("href", "/tasks");
+		expect(screen.getByRole("link", { name: "Настройки" })).toHaveAttribute("href", "/settings");
+	});
+
+	test("nav has aria-label", () => {
+		renderBar();
+		expect(screen.getByRole("navigation", { name: "Основная навигация" })).toBeInTheDocument();
+	});
+});
+
+describe("BottomTabBar active state", () => {
+	test("marks Закупки active at /procurement", () => {
+		renderBar("/procurement");
+		expect(screen.getByRole("link", { name: "Закупки" })).toHaveAttribute("aria-current", "page");
+		expect(screen.getByRole("link", { name: "Задачи" })).not.toHaveAttribute("aria-current");
+	});
+
+	test("marks Задачи active at /tasks", () => {
+		renderBar("/tasks");
+		expect(screen.getByRole("link", { name: "Задачи" })).toHaveAttribute("aria-current", "page");
+	});
+
+	test("marks Настройки active at /settings", () => {
+		renderBar("/settings");
+		expect(screen.getByRole("link", { name: "Настройки" })).toHaveAttribute("aria-current", "page");
+	});
+
+	test("marks Настройки active for deep routes (/settings/profile)", () => {
+		renderBar("/settings/profile");
+		expect(screen.getByRole("link", { name: "Настройки" })).toHaveAttribute("aria-current", "page");
+	});
+});
+
+describe("BottomTabBar visibility", () => {
+	test("container has mobile-only visibility classes (hidden on desktop)", () => {
+		renderBar();
+		const bar = screen.getByTestId("bottom-tab-bar");
+		expect(bar.className).toContain("md:hidden");
+	});
+});
+
+describe("BottomTabBar navigation", () => {
+	test("clicking an item navigates", async () => {
+		render(
+			<MemoryRouter initialEntries={["/procurement"]}>
+				<BottomTabBar />
+				<Routes>
+					<Route path="/procurement" element={<div>procurement-page</div>} />
+					<Route path="/settings" element={<div>settings-page</div>} />
+				</Routes>
+			</MemoryRouter>,
+		);
+		await userEvent.setup().click(screen.getByRole("link", { name: "Настройки" }));
+		expect(screen.getByText("settings-page")).toBeInTheDocument();
+	});
+});

--- a/src/components/bottom-tab-bar.tsx
+++ b/src/components/bottom-tab-bar.tsx
@@ -1,0 +1,39 @@
+import { ListTodo, Package, Settings } from "lucide-react";
+import { Link, useLocation } from "react-router";
+import { cn } from "@/lib/utils";
+
+const TAB_ITEMS = [
+	{ path: "/procurement", label: "Закупки", icon: Package },
+	{ path: "/tasks", label: "Задачи", icon: ListTodo },
+	{ path: "/settings", label: "Настройки", icon: Settings },
+] as const;
+
+export function BottomTabBar() {
+	const { pathname } = useLocation();
+	return (
+		<nav
+			aria-label="Основная навигация"
+			className="flex shrink-0 border-t border-sidebar-border bg-sidebar md:hidden"
+			data-testid="bottom-tab-bar"
+		>
+			{TAB_ITEMS.map(({ path, label, icon: Icon }) => {
+				const active = pathname.startsWith(path);
+				return (
+					<Link
+						key={path}
+						to={path}
+						aria-label={label}
+						aria-current={active ? "page" : undefined}
+						className={cn(
+							"flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-[0.6875rem] transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+							active ? "text-sidebar-accent-foreground" : "text-sidebar-foreground",
+						)}
+					>
+						<Icon className="size-5" aria-hidden="true" />
+						<span>{label}</span>
+					</Link>
+				);
+			})}
+		</nav>
+	);
+}

--- a/src/components/filter-chip.tsx
+++ b/src/components/filter-chip.tsx
@@ -1,0 +1,35 @@
+import { X } from "lucide-react";
+
+interface FilterChipProps {
+	label: string;
+	color?: string;
+	onRemove: () => void;
+	removeAriaLabel: string;
+	testId?: string;
+}
+
+export function FilterChip({ label, color, onRemove, removeAriaLabel, testId }: FilterChipProps) {
+	return (
+		<span
+			data-testid={testId}
+			className="inline-flex h-6 items-center gap-1.5 rounded-full border border-border bg-muted/50 py-0.5 pr-0.5 pl-2 text-xs"
+		>
+			{color && (
+				<span
+					className="size-2 shrink-0 rounded-full"
+					style={{ backgroundColor: `var(--folder-${color})` }}
+					aria-hidden="true"
+				/>
+			)}
+			<span className="max-w-[10rem] truncate">{label}</span>
+			<button
+				type="button"
+				onClick={onRemove}
+				aria-label={removeAriaLabel}
+				className="flex size-4 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted-foreground/10 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+			>
+				<X className="size-3" aria-hidden="true" />
+			</button>
+		</span>
+	);
+}

--- a/src/components/filters-popover.test.tsx
+++ b/src/components/filters-popover.test.tsx
@@ -1,0 +1,501 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { CompanySummary, FilterState, Folder } from "@/data/types";
+import { makeCompany } from "@/test-utils";
+import { FiltersPopover } from "./filters-popover";
+
+const MOCK_FOLDERS: Folder[] = [
+	{ id: "f1", name: "Металлопрокат", color: "blue" },
+	{ id: "f2", name: "Стройматериалы", color: "green" },
+];
+
+const MOCK_COUNTS: Record<string, number> = {
+	all: 75,
+	none: 47,
+	f1: 18,
+	f2: 10,
+};
+
+const COMPANIES: CompanySummary[] = [
+	makeCompany("c1", { name: "Альфа", procurementItemCount: 15 }),
+	makeCompany("c2", { name: "Бета", procurementItemCount: 8 }),
+];
+
+const DEFAULT_FILTERS: FilterState = { deviation: "all", status: "all" };
+
+interface RenderOptions {
+	filters?: FilterState;
+	activeFolder?: string | undefined;
+	companies?: CompanySummary[];
+	selectedCompany?: string | undefined;
+	showCompanies?: boolean;
+	foldersLoading?: boolean;
+	folders?: Folder[];
+	onFiltersChange?: (filters: FilterState) => void;
+	onFolderSelect?: (folder: string | undefined) => void;
+	onCreateFolder?: (name: string) => void;
+	onRenameFolder?: (id: string, name: string) => void;
+	onRecolorFolder?: (id: string, color: string) => void;
+	onDeleteFolder?: (id: string) => void;
+	onCompanySelect?: (company: string | undefined) => void;
+}
+
+function renderPopover(opts: RenderOptions = {}) {
+	const onFiltersChange = opts.onFiltersChange ?? vi.fn();
+	const onFolderSelect = opts.onFolderSelect ?? vi.fn();
+	const onCreateFolder = opts.onCreateFolder ?? vi.fn();
+	const onRenameFolder = opts.onRenameFolder ?? vi.fn();
+	const onRecolorFolder = opts.onRecolorFolder ?? vi.fn();
+	const onDeleteFolder = opts.onDeleteFolder ?? vi.fn();
+	const onCompanySelect = opts.onCompanySelect ?? vi.fn();
+
+	const utils = render(
+		<TooltipProvider>
+			<FiltersPopover
+				filters={opts.filters ?? DEFAULT_FILTERS}
+				onFiltersChange={onFiltersChange}
+				folders={opts.folders ?? MOCK_FOLDERS}
+				folderCounts={MOCK_COUNTS}
+				foldersLoading={opts.foldersLoading}
+				activeFolder={opts.activeFolder}
+				onFolderSelect={onFolderSelect}
+				onCreateFolder={onCreateFolder}
+				onRenameFolder={onRenameFolder}
+				onRecolorFolder={onRecolorFolder}
+				onDeleteFolder={onDeleteFolder}
+				companies={opts.companies ?? COMPANIES}
+				selectedCompany={opts.selectedCompany}
+				onCompanySelect={onCompanySelect}
+				showCompanies={opts.showCompanies ?? false}
+			/>
+		</TooltipProvider>,
+	);
+
+	return {
+		...utils,
+		mocks: {
+			onFiltersChange,
+			onFolderSelect,
+			onCreateFolder,
+			onRenameFolder,
+			onRecolorFolder,
+			onDeleteFolder,
+			onCompanySelect,
+		},
+	};
+}
+
+function openPopover() {
+	fireEvent.click(screen.getByRole("button", { name: "Фильтры" }));
+}
+
+beforeEach(() => {
+	localStorage.clear();
+});
+
+describe("FiltersPopover — section visibility", () => {
+	test("renders category, deviation, status sections by default", () => {
+		renderPopover();
+		openPopover();
+
+		expect(screen.getByTestId("filters-section-category")).toBeInTheDocument();
+		expect(screen.getByTestId("filters-section-deviation")).toBeInTheDocument();
+		expect(screen.getByTestId("filters-section-status")).toBeInTheDocument();
+	});
+
+	test("hides Компания section in single-company workspace", () => {
+		renderPopover({ showCompanies: false });
+		openPopover();
+
+		expect(screen.queryByTestId("filters-section-company")).not.toBeInTheDocument();
+	});
+
+	test("shows Компания section in multi-company workspace", () => {
+		renderPopover({ showCompanies: true });
+		openPopover();
+
+		expect(screen.getByTestId("filters-section-company")).toBeInTheDocument();
+		expect(screen.getByText("Альфа")).toBeInTheDocument();
+		expect(screen.getByText("Бета")).toBeInTheDocument();
+	});
+
+	test("sections appear in order: Компания → Категория → Отклонение → Статус", () => {
+		renderPopover({ showCompanies: true });
+		openPopover();
+
+		const sections = [
+			screen.getByTestId("filters-section-company"),
+			screen.getByTestId("filters-section-category"),
+			screen.getByTestId("filters-section-deviation"),
+			screen.getByTestId("filters-section-status"),
+		];
+
+		for (let i = 0; i < sections.length - 1; i++) {
+			expect(sections[i].compareDocumentPosition(sections[i + 1]) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+		}
+	});
+});
+
+describe("FiltersPopover — Компания section", () => {
+	test("shows company name and procurement count", () => {
+		renderPopover({ showCompanies: true });
+		openPopover();
+
+		const section = screen.getByTestId("filters-section-company");
+		expect(within(section).getByText("Альфа")).toBeInTheDocument();
+		expect(within(section).getByText("15")).toBeInTheDocument();
+	});
+
+	test("selecting a company calls onCompanySelect with id", () => {
+		const onCompanySelect = vi.fn();
+		renderPopover({ showCompanies: true, onCompanySelect });
+		openPopover();
+
+		fireEvent.click(screen.getByText("Альфа"));
+		expect(onCompanySelect).toHaveBeenCalledWith("c1");
+	});
+
+	test("selecting an already-selected company clears it", () => {
+		const onCompanySelect = vi.fn();
+		renderPopover({ showCompanies: true, selectedCompany: "c1", onCompanySelect });
+		openPopover();
+
+		fireEvent.click(screen.getByText("Альфа"));
+		expect(onCompanySelect).toHaveBeenCalledWith(undefined);
+	});
+
+	test("active company row has highlight class", () => {
+		renderPopover({ showCompanies: true, selectedCompany: "c1" });
+		openPopover();
+
+		const btn = screen.getByText("Альфа").closest("button") as HTMLElement;
+		expect(btn.className).toContain("text-highlight-foreground");
+	});
+});
+
+describe("FiltersPopover — Категория section", () => {
+	test("renders system entries (Все закупки, Без категории) with counts", () => {
+		renderPopover();
+		openPopover();
+
+		expect(screen.getByText("Все закупки")).toBeInTheDocument();
+		expect(screen.getByText("75")).toBeInTheDocument();
+		expect(screen.getByText("Без категории")).toBeInTheDocument();
+		expect(screen.getByText("47")).toBeInTheDocument();
+	});
+
+	test("renders folders with names, counts, and color dots", () => {
+		renderPopover();
+		openPopover();
+
+		expect(screen.getByText("Металлопрокат")).toBeInTheDocument();
+		expect(screen.getByText("18")).toBeInTheDocument();
+		expect(screen.getByText("Стройматериалы")).toBeInTheDocument();
+		expect(screen.getByText("10")).toBeInTheDocument();
+
+		const dot = screen.getByTestId("filters-folder-dot-f1");
+		expect(dot.style.backgroundColor).toBe("var(--folder-blue)");
+	});
+
+	test("clicking Все закупки calls onFolderSelect(undefined)", () => {
+		const onFolderSelect = vi.fn();
+		renderPopover({ activeFolder: "f1", onFolderSelect });
+		openPopover();
+
+		fireEvent.click(screen.getByText("Все закупки"));
+		expect(onFolderSelect).toHaveBeenCalledWith(undefined);
+	});
+
+	test("clicking Без категории calls onFolderSelect('none')", () => {
+		const onFolderSelect = vi.fn();
+		renderPopover({ onFolderSelect });
+		openPopover();
+
+		fireEvent.click(screen.getByText("Без категории"));
+		expect(onFolderSelect).toHaveBeenCalledWith("none");
+	});
+
+	test("clicking a folder calls onFolderSelect with folder id", () => {
+		const onFolderSelect = vi.fn();
+		renderPopover({ onFolderSelect });
+		openPopover();
+
+		fireEvent.click(screen.getByText("Металлопрокат"));
+		expect(onFolderSelect).toHaveBeenCalledWith("f1");
+	});
+
+	test("highlights active folder", () => {
+		renderPopover({ activeFolder: "f1" });
+		openPopover();
+
+		const btn = screen.getByText("Металлопрокат").closest("button") as HTMLElement;
+		expect(btn.className).toContain("text-highlight-foreground");
+	});
+
+	test("shows skeletons while foldersLoading", () => {
+		renderPopover({ foldersLoading: true });
+		openPopover();
+
+		expect(screen.getByTestId("filters-folder-skeletons")).toBeInTheDocument();
+		expect(screen.queryByText("Металлопрокат")).not.toBeInTheDocument();
+	});
+});
+
+describe("FiltersPopover — folder CRUD (create)", () => {
+	test("clicking Новая категория shows inline input", async () => {
+		renderPopover();
+		openPopover();
+
+		fireEvent.click(screen.getByRole("button", { name: "Новая категория" }));
+		expect(screen.getByRole("textbox", { name: "Название категории" })).toBeInTheDocument();
+	});
+
+	test("Enter with a name calls onCreateFolder", async () => {
+		const onCreateFolder = vi.fn();
+		renderPopover({ onCreateFolder });
+		openPopover();
+
+		fireEvent.click(screen.getByRole("button", { name: "Новая категория" }));
+		const input = screen.getByRole("textbox", { name: "Название категории" });
+		const user = userEvent.setup();
+		await user.type(input, "Тест{Enter}");
+
+		expect(onCreateFolder).toHaveBeenCalledWith("Тест");
+	});
+
+	test("Esc cancels creation", async () => {
+		const onCreateFolder = vi.fn();
+		renderPopover({ onCreateFolder });
+		openPopover();
+
+		fireEvent.click(screen.getByRole("button", { name: "Новая категория" }));
+		const input = screen.getByRole("textbox", { name: "Название категории" });
+		const user = userEvent.setup();
+		await user.type(input, "Тест{Escape}");
+
+		expect(onCreateFolder).not.toHaveBeenCalled();
+		expect(screen.queryByRole("textbox", { name: "Название категории" })).not.toBeInTheDocument();
+	});
+
+	test("creation row shows color dot", async () => {
+		renderPopover();
+		openPopover();
+
+		fireEvent.click(screen.getByRole("button", { name: "Новая категория" }));
+		expect(screen.getByTestId("creating-folder-dot")).toBeInTheDocument();
+	});
+});
+
+async function openFolderMenu(folderName: string) {
+	const user = userEvent.setup();
+	await user.click(screen.getByRole("button", { name: `Меню категории ${folderName}` }));
+	await screen.findByText("Переименовать");
+}
+
+describe("FiltersPopover — folder CRUD (rename)", () => {
+	test("clicking Переименовать shows inline input with current name", async () => {
+		renderPopover();
+		openPopover();
+		await openFolderMenu("Металлопрокат");
+		fireEvent.click(screen.getByText("Переименовать"));
+
+		const input = screen.getByDisplayValue("Металлопрокат");
+		expect(input).toBeInTheDocument();
+	});
+
+	test("Enter saves renamed folder", async () => {
+		const onRenameFolder = vi.fn();
+		renderPopover({ onRenameFolder });
+		openPopover();
+		await openFolderMenu("Металлопрокат");
+		fireEvent.click(screen.getByText("Переименовать"));
+
+		const input = screen.getByDisplayValue("Металлопрокат");
+		const user = userEvent.setup();
+		await user.clear(input);
+		await user.type(input, "Новое имя{Enter}");
+
+		expect(onRenameFolder).toHaveBeenCalledWith("f1", "Новое имя");
+	});
+
+	test("Esc cancels rename", async () => {
+		const onRenameFolder = vi.fn();
+		renderPopover({ onRenameFolder });
+		openPopover();
+		await openFolderMenu("Металлопрокат");
+		fireEvent.click(screen.getByText("Переименовать"));
+
+		const input = screen.getByDisplayValue("Металлопрокат");
+		fireEvent.keyDown(input, { key: "Escape" });
+
+		expect(onRenameFolder).not.toHaveBeenCalled();
+	});
+});
+
+describe("FiltersPopover — folder CRUD (recolor)", () => {
+	test("color picker shows 8 dots", async () => {
+		renderPopover();
+		openPopover();
+		await openFolderMenu("Металлопрокат");
+
+		const picker = screen.getByTestId("filters-color-picker-f1");
+		const dots = picker.querySelectorAll("button");
+		expect(dots).toHaveLength(8);
+	});
+
+	test("active color has checkmark", async () => {
+		renderPopover();
+		openPopover();
+		await openFolderMenu("Металлопрокат");
+
+		const blueBtn = screen.getByTestId("filters-color-dot-blue");
+		expect(within(blueBtn).getByTestId("filters-color-check")).toBeInTheDocument();
+	});
+
+	test("clicking a color calls onRecolorFolder", async () => {
+		const onRecolorFolder = vi.fn();
+		renderPopover({ onRecolorFolder });
+		openPopover();
+		await openFolderMenu("Металлопрокат");
+
+		fireEvent.click(screen.getByTestId("filters-color-dot-red"));
+
+		expect(onRecolorFolder).toHaveBeenCalledWith("f1", "red");
+	});
+});
+
+describe("FiltersPopover — folder CRUD (delete)", () => {
+	test("clicking Удалить shows confirmation dialog", async () => {
+		renderPopover();
+		openPopover();
+		await openFolderMenu("Металлопрокат");
+		fireEvent.click(screen.getByText("Удалить"));
+
+		expect(await screen.findByText("Удалить категорию?")).toBeInTheDocument();
+	});
+
+	test("confirming delete calls onDeleteFolder", async () => {
+		const onDeleteFolder = vi.fn();
+		renderPopover({ onDeleteFolder });
+		openPopover();
+		await openFolderMenu("Металлопрокат");
+		fireEvent.click(screen.getByText("Удалить"));
+
+		await screen.findByText("Удалить категорию?");
+		fireEvent.click(screen.getByRole("button", { name: "Удалить" }));
+
+		expect(onDeleteFolder).toHaveBeenCalledWith("f1");
+	});
+
+	test("cancelling delete does not call onDeleteFolder", async () => {
+		const onDeleteFolder = vi.fn();
+		renderPopover({ onDeleteFolder });
+		openPopover();
+		await openFolderMenu("Металлопрокат");
+		fireEvent.click(screen.getByText("Удалить"));
+
+		await screen.findByText("Удалить категорию?");
+		fireEvent.click(screen.getByRole("button", { name: "Отмена" }));
+
+		expect(onDeleteFolder).not.toHaveBeenCalled();
+	});
+
+	test("deleting active folder switches to Все закупки", async () => {
+		const onDeleteFolder = vi.fn();
+		const onFolderSelect = vi.fn();
+		renderPopover({ activeFolder: "f1", onDeleteFolder, onFolderSelect });
+		openPopover();
+		await openFolderMenu("Металлопрокат");
+		fireEvent.click(screen.getByText("Удалить"));
+
+		await screen.findByText("Удалить категорию?");
+		fireEvent.click(screen.getByRole("button", { name: "Удалить" }));
+
+		expect(onDeleteFolder).toHaveBeenCalledWith("f1");
+		expect(onFolderSelect).toHaveBeenCalledWith(undefined);
+	});
+});
+
+describe("FiltersPopover — Отклонение section", () => {
+	test("renders deviation presets", () => {
+		renderPopover();
+		openPopover();
+
+		const section = screen.getByTestId("filters-section-deviation");
+		expect(within(section).getByText("С переплатой")).toBeInTheDocument();
+		expect(within(section).getByText("С экономией")).toBeInTheDocument();
+	});
+
+	test("clicking a preset toggles deviation filter", () => {
+		const onFiltersChange = vi.fn();
+		renderPopover({ onFiltersChange });
+		openPopover();
+
+		fireEvent.click(screen.getByText("С переплатой"));
+		expect(onFiltersChange).toHaveBeenCalledWith({ deviation: "overpaying", status: "all" });
+	});
+
+	test("clicking an active preset resets it", () => {
+		const onFiltersChange = vi.fn();
+		renderPopover({ filters: { deviation: "overpaying", status: "all" }, onFiltersChange });
+		openPopover();
+
+		fireEvent.click(screen.getByText("С переплатой"));
+		expect(onFiltersChange).toHaveBeenCalledWith({ deviation: "all", status: "all" });
+	});
+
+	test("highlights active deviation preset", () => {
+		renderPopover({ filters: { deviation: "saving", status: "all" } });
+		openPopover();
+
+		const btn = screen.getByText("С экономией").closest("button") as HTMLElement;
+		expect(btn.className).toContain("text-highlight-foreground");
+	});
+});
+
+describe("FiltersPopover — Статус section", () => {
+	test("renders all status presets", () => {
+		renderPopover();
+		openPopover();
+
+		const section = screen.getByTestId("filters-section-status");
+		expect(within(section).getByText("Ожидание аналитики")).toBeInTheDocument();
+		expect(within(section).getByText("Ищем поставщиков")).toBeInTheDocument();
+		expect(within(section).getByText("Ведём переговоры")).toBeInTheDocument();
+		expect(within(section).getByText("Переговоры завершены")).toBeInTheDocument();
+	});
+
+	test("clicking a preset toggles status filter", () => {
+		const onFiltersChange = vi.fn();
+		renderPopover({ onFiltersChange });
+		openPopover();
+
+		fireEvent.click(screen.getByText("Ищем поставщиков"));
+		expect(onFiltersChange).toHaveBeenCalledWith({ deviation: "all", status: "searching" });
+	});
+
+	test("clicking an active status resets it", () => {
+		const onFiltersChange = vi.fn();
+		renderPopover({ filters: { deviation: "all", status: "searching" }, onFiltersChange });
+		openPopover();
+
+		fireEvent.click(screen.getByText("Ищем поставщиков"));
+		expect(onFiltersChange).toHaveBeenCalledWith({ deviation: "all", status: "all" });
+	});
+});
+
+describe("FiltersPopover — trigger", () => {
+	test("filter button has no active dot when filters are default", () => {
+		renderPopover();
+		const btn = screen.getByRole("button", { name: "Фильтры" });
+		expect(btn.querySelector(".bg-primary")).not.toBeInTheDocument();
+	});
+
+	test("filter button shows active dot when deviation or status is set", () => {
+		renderPopover({ filters: { deviation: "overpaying", status: "all" } });
+		const btn = screen.getByRole("button", { name: "Фильтры" });
+		expect(btn.querySelector(".bg-primary")).toBeInTheDocument();
+	});
+});

--- a/src/components/filters-popover.tsx
+++ b/src/components/filters-popover.tsx
@@ -1,0 +1,502 @@
+import { Check, CirclePlus, EllipsisVertical, ListFilter, Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { CompanySummary, DeviationFilter, FilterState, Folder, StatusFilter } from "@/data/types";
+import { FOLDER_COLORS, FOLDER_NAME_MAX_LENGTH, STATUS_LABELS } from "@/data/types";
+import { nextUnusedColor } from "@/data/use-folders";
+import { useInlineEdit } from "@/hooks/use-inline-edit";
+import { useMenuEditGuard } from "@/hooks/use-menu-edit-guard";
+import { cn } from "@/lib/utils";
+
+const DEVIATION_PRESETS: { label: string; value: DeviationFilter }[] = [
+	{ label: "С переплатой", value: "overpaying" },
+	{ label: "С экономией", value: "saving" },
+];
+
+const STATUS_PRESETS: { label: string; value: StatusFilter }[] = [
+	{ label: STATUS_LABELS.awaiting_analytics, value: "awaiting_analytics" },
+	{ label: STATUS_LABELS.searching, value: "searching" },
+	{ label: STATUS_LABELS.negotiating, value: "negotiating" },
+	{ label: STATUS_LABELS.completed, value: "completed" },
+];
+
+const ROW_BTN =
+	"flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+const ROW_BTN_ACTIVE = "font-medium text-highlight-foreground";
+const SECTION_LABEL = "px-2 pt-1 pb-0.5 text-xs font-medium text-muted-foreground";
+
+function hasActiveFilter(filters: FilterState): boolean {
+	return filters.deviation !== "all" || filters.status !== "all";
+}
+
+interface FiltersPopoverProps {
+	filters: FilterState;
+	onFiltersChange: (filters: FilterState) => void;
+	folders: Folder[];
+	folderCounts: Record<string, number>;
+	foldersLoading?: boolean;
+	activeFolder: string | undefined;
+	onFolderSelect: (folder: string | undefined) => void;
+	onCreateFolder: (name: string) => void;
+	onRenameFolder: (id: string, name: string) => void;
+	onRecolorFolder: (id: string, color: string) => void;
+	onDeleteFolder: (id: string) => void;
+	companies?: CompanySummary[];
+	selectedCompany?: string | undefined;
+	onCompanySelect?: (company: string | undefined) => void;
+	showCompanies?: boolean;
+}
+
+export function FiltersPopover({
+	filters,
+	onFiltersChange,
+	folders,
+	folderCounts,
+	foldersLoading,
+	activeFolder,
+	onFolderSelect,
+	onCreateFolder,
+	onRenameFolder,
+	onRecolorFolder,
+	onDeleteFolder,
+	companies,
+	selectedCompany,
+	onCompanySelect,
+	showCompanies = false,
+}: FiltersPopoverProps) {
+	return (
+		<Popover>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<PopoverTrigger asChild>
+						<Button type="button" variant="ghost" size="icon-sm" aria-label="Фильтры" className="relative">
+							<ListFilter aria-hidden="true" />
+							{hasActiveFilter(filters) && (
+								<span className="absolute -right-1 -top-1 size-2.5 rounded-full bg-primary" />
+							)}
+						</Button>
+					</PopoverTrigger>
+				</TooltipTrigger>
+				<TooltipContent>Фильтры</TooltipContent>
+			</Tooltip>
+			<PopoverContent align="end" className="w-72 p-0">
+				<div className="flex max-h-[70vh] flex-col overflow-y-auto p-1.5">
+					{showCompanies && onCompanySelect && (
+						<>
+							<CompanySection
+								companies={companies ?? []}
+								selectedCompany={selectedCompany}
+								onCompanySelect={onCompanySelect}
+							/>
+							<Divider />
+						</>
+					)}
+					<CategorySection
+						folders={folders}
+						folderCounts={folderCounts}
+						foldersLoading={foldersLoading}
+						activeFolder={activeFolder}
+						onFolderSelect={onFolderSelect}
+						onCreateFolder={onCreateFolder}
+						onRenameFolder={onRenameFolder}
+						onRecolorFolder={onRecolorFolder}
+						onDeleteFolder={onDeleteFolder}
+					/>
+					<Divider />
+					<DeviationSection filters={filters} onFiltersChange={onFiltersChange} />
+					<Divider />
+					<StatusSection filters={filters} onFiltersChange={onFiltersChange} />
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+function Divider() {
+	return <div className="my-1 h-px bg-border" />;
+}
+
+function CompanySection({
+	companies,
+	selectedCompany,
+	onCompanySelect,
+}: {
+	companies: CompanySummary[];
+	selectedCompany: string | undefined;
+	onCompanySelect: (company: string | undefined) => void;
+}) {
+	return (
+		<div data-testid="filters-section-company" className="flex flex-col gap-0.5">
+			<div className={SECTION_LABEL}>Компания</div>
+			{companies.map((company) => {
+				const isActive = selectedCompany === company.id;
+				return (
+					<button
+						key={company.id}
+						type="button"
+						className={cn(ROW_BTN, isActive && ROW_BTN_ACTIVE)}
+						onClick={() => onCompanySelect(isActive ? undefined : company.id)}
+					>
+						<span className="truncate">{company.name}</span>
+						<span className="shrink-0 tabular-nums text-xs text-muted-foreground">{company.procurementItemCount}</span>
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+function CategorySection({
+	folders,
+	folderCounts,
+	foldersLoading,
+	activeFolder,
+	onFolderSelect,
+	onCreateFolder,
+	onRenameFolder,
+	onRecolorFolder,
+	onDeleteFolder,
+}: {
+	folders: Folder[];
+	folderCounts: Record<string, number>;
+	foldersLoading?: boolean;
+	activeFolder: string | undefined;
+	onFolderSelect: (folder: string | undefined) => void;
+	onCreateFolder: (name: string) => void;
+	onRenameFolder: (id: string, name: string) => void;
+	onRecolorFolder: (id: string, color: string) => void;
+	onDeleteFolder: (id: string) => void;
+}) {
+	const [isCreating, setIsCreating] = useState(false);
+	const [editingId, setEditingId] = useState<string | null>(null);
+
+	function handleCreate(name: string) {
+		onCreateFolder(name);
+		setIsCreating(false);
+	}
+
+	function handleDelete(id: string) {
+		if (activeFolder === id) onFolderSelect(undefined);
+		onDeleteFolder(id);
+	}
+
+	return (
+		<div data-testid="filters-section-category" className="flex flex-col gap-0.5">
+			<div className="flex items-center justify-between">
+				<div className={SECTION_LABEL}>Категория</div>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button variant="ghost" size="icon-xs" onClick={() => setIsCreating(true)} aria-label="Новая категория">
+							<CirclePlus className="size-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="right">Добавить категорию</TooltipContent>
+				</Tooltip>
+			</div>
+
+			<button
+				type="button"
+				className={cn(ROW_BTN, activeFolder === undefined && ROW_BTN_ACTIVE)}
+				onClick={() => onFolderSelect(undefined)}
+			>
+				<span>Все закупки</span>
+				<span className="tabular-nums text-xs text-muted-foreground">{folderCounts.all ?? 0}</span>
+			</button>
+			<button
+				type="button"
+				className={cn(ROW_BTN, activeFolder === "none" && ROW_BTN_ACTIVE)}
+				onClick={() => onFolderSelect("none")}
+			>
+				<span>Без категории</span>
+				<span className="tabular-nums text-xs text-muted-foreground">{folderCounts.none ?? 0}</span>
+			</button>
+
+			{foldersLoading ? (
+				<div className="space-y-1 px-2 pt-1" data-testid="filters-folder-skeletons">
+					{["skel-a", "skel-b", "skel-c"].map((id) => (
+						<div key={id} className="flex items-center gap-2 py-1">
+							<Skeleton className="size-2.5 rounded-full" />
+							<Skeleton className="h-4 flex-1" />
+						</div>
+					))}
+				</div>
+			) : (
+				<>
+					{folders.map((folder) =>
+						editingId === folder.id ? (
+							<InlineFolderRow
+								key={folder.id}
+								color={folder.color}
+								defaultValue={folder.name}
+								onSave={(name) => {
+									onRenameFolder(folder.id, name);
+									setEditingId(null);
+								}}
+								onCancel={() => setEditingId(null)}
+							/>
+						) : (
+							<FolderRow
+								key={folder.id}
+								folder={folder}
+								count={folderCounts[folder.id] ?? 0}
+								active={activeFolder === folder.id}
+								onClick={() => onFolderSelect(folder.id)}
+								onRename={() => setEditingId(folder.id)}
+								onRecolor={(color) => onRecolorFolder(folder.id, color)}
+								onDelete={() => handleDelete(folder.id)}
+							/>
+						),
+					)}
+					{isCreating && (
+						<InlineFolderRow
+							color={nextUnusedColor(folders)}
+							dotTestId="creating-folder-dot"
+							onSave={handleCreate}
+							onCancel={() => setIsCreating(false)}
+						/>
+					)}
+				</>
+			)}
+		</div>
+	);
+}
+
+function FolderRow({
+	folder,
+	count,
+	active,
+	onClick,
+	onRename,
+	onRecolor,
+	onDelete,
+}: {
+	folder: Folder;
+	count: number;
+	active: boolean;
+	onClick: () => void;
+	onRename: () => void;
+	onRecolor: (color: string) => void;
+	onDelete: () => void;
+}) {
+	const [deleteOpen, setDeleteOpen] = useState(false);
+	const { willEditRef, onCloseAutoFocus } = useMenuEditGuard();
+
+	return (
+		<div className="group relative">
+			<button type="button" className={cn(ROW_BTN, "pr-12", active && ROW_BTN_ACTIVE)} onClick={onClick}>
+				<span className="flex min-w-0 items-center gap-2">
+					<span
+						className="size-2.5 shrink-0 rounded-full"
+						style={{ backgroundColor: `var(--folder-${folder.color})` }}
+						aria-hidden="true"
+						data-testid={`filters-folder-dot-${folder.id}`}
+					/>
+					<span className="truncate">{folder.name}</span>
+				</span>
+			</button>
+
+			<span
+				className={cn(
+					"pointer-events-none absolute right-7 top-1/2 -translate-y-1/2",
+					"tabular-nums text-xs text-muted-foreground",
+					"group-hover:invisible group-focus-within:invisible",
+				)}
+				aria-hidden="true"
+			>
+				{count}
+			</span>
+
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<button
+						type="button"
+						className={cn(
+							"absolute right-1 top-1/2 -translate-y-1/2 rounded p-0.5",
+							"text-muted-foreground hover:text-foreground",
+							"invisible group-hover:visible group-focus-within:visible",
+						)}
+						onClick={(e) => e.stopPropagation()}
+						aria-label={`Меню категории ${folder.name}`}
+					>
+						<EllipsisVertical className="size-3.5" />
+					</button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end" side="right" className="min-w-40" onCloseAutoFocus={onCloseAutoFocus}>
+					<DropdownMenuItem
+						onSelect={() => {
+							willEditRef.current = true;
+							onRename();
+						}}
+					>
+						<Pencil className="size-3.5" />
+						Переименовать
+					</DropdownMenuItem>
+					<DropdownMenuSeparator />
+					<div className="px-1.5 py-1" data-testid={`filters-color-picker-${folder.id}`}>
+						<div className="flex max-w-[92px] flex-wrap gap-1">
+							{FOLDER_COLORS.map((color) => (
+								<button
+									key={color}
+									type="button"
+									className="flex size-5 items-center justify-center rounded-full transition-transform hover:scale-110"
+									style={{ backgroundColor: `var(--folder-${color})` }}
+									onClick={() => onRecolor(color)}
+									data-testid={`filters-color-dot-${color}`}
+									aria-label={`Цвет ${color}`}
+								>
+									{folder.color === color && <Check className="size-3 text-white" data-testid="filters-color-check" />}
+								</button>
+							))}
+						</div>
+					</div>
+					<DropdownMenuSeparator />
+					<DropdownMenuItem variant="destructive" onSelect={() => setDeleteOpen(true)}>
+						<Trash2 className="size-3.5" />
+						Удалить
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+
+			<AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+				<AlertDialogContent size="sm">
+					<AlertDialogHeader>
+						<AlertDialogTitle>Удалить категорию?</AlertDialogTitle>
+						<AlertDialogDescription>
+							Категория «{folder.name}» будет удалена. Закупки из этой категории не будут удалены.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Отмена</AlertDialogCancel>
+						<AlertDialogAction
+							variant="destructive"
+							onClick={() => {
+								onDelete();
+								setDeleteOpen(false);
+							}}
+						>
+							Удалить
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
+}
+
+function InlineFolderRow({
+	color,
+	defaultValue,
+	dotTestId,
+	onSave,
+	onCancel,
+}: {
+	color: string;
+	defaultValue?: string;
+	dotTestId?: string;
+	onSave: (value: string) => void;
+	onCancel: () => void;
+}) {
+	const { inputRef, handleKeyDown, handleBlur } = useInlineEdit({
+		onSave,
+		onCancel,
+		selectOnMount: !!defaultValue,
+		deferFocus: !!defaultValue,
+	});
+
+	return (
+		<div className="flex items-center gap-2 rounded-md px-2 py-1.5">
+			<span
+				className="size-2.5 shrink-0 rounded-full"
+				style={{ backgroundColor: `var(--folder-${color})` }}
+				aria-hidden="true"
+				data-testid={dotTestId}
+			/>
+			<input
+				ref={inputRef}
+				type="text"
+				className="h-5 flex-1 bg-transparent text-sm outline-none"
+				defaultValue={defaultValue}
+				maxLength={FOLDER_NAME_MAX_LENGTH}
+				aria-label="Название категории"
+				spellCheck={false}
+				autoComplete="off"
+				onKeyDown={handleKeyDown}
+				onBlur={handleBlur}
+			/>
+		</div>
+	);
+}
+
+function DeviationSection({
+	filters,
+	onFiltersChange,
+}: {
+	filters: FilterState;
+	onFiltersChange: (filters: FilterState) => void;
+}) {
+	function toggle(value: DeviationFilter) {
+		onFiltersChange({ ...filters, deviation: filters.deviation === value ? "all" : value });
+	}
+	return (
+		<div data-testid="filters-section-deviation" className="flex flex-col gap-0.5">
+			<div className={SECTION_LABEL}>Отклонение</div>
+			{DEVIATION_PRESETS.map((preset) => (
+				<button
+					key={preset.value}
+					type="button"
+					className={cn(ROW_BTN, filters.deviation === preset.value && ROW_BTN_ACTIVE)}
+					onClick={() => toggle(preset.value)}
+				>
+					{preset.label}
+				</button>
+			))}
+		</div>
+	);
+}
+
+function StatusSection({
+	filters,
+	onFiltersChange,
+}: {
+	filters: FilterState;
+	onFiltersChange: (filters: FilterState) => void;
+}) {
+	function toggle(value: StatusFilter) {
+		onFiltersChange({ ...filters, status: filters.status === value ? "all" : value });
+	}
+	return (
+		<div data-testid="filters-section-status" className="flex flex-col gap-0.5">
+			<div className={SECTION_LABEL}>Статус</div>
+			{STATUS_PRESETS.map((preset) => (
+				<button
+					key={preset.value}
+					type="button"
+					className={cn(ROW_BTN, filters.status === preset.value && ROW_BTN_ACTIVE)}
+					onClick={() => toggle(preset.value)}
+				>
+					{preset.label}
+				</button>
+			))}
+		</div>
+	);
+}

--- a/src/components/page-toolbar.test.tsx
+++ b/src/components/page-toolbar.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { PageToolbar } from "./page-toolbar";
+
+describe("PageToolbar", () => {
+	test("renders all three zones when provided", () => {
+		render(<PageToolbar left={<span>L</span>} middle={<span>M</span>} right={<span>R</span>} />);
+		expect(screen.getByTestId("page-toolbar-left")).toHaveTextContent("L");
+		expect(screen.getByTestId("page-toolbar-middle")).toHaveTextContent("M");
+		expect(screen.getByTestId("page-toolbar-right")).toHaveTextContent("R");
+	});
+
+	test("omits left zone when not provided", () => {
+		render(<PageToolbar middle={<span>M</span>} right={<span>R</span>} />);
+		expect(screen.queryByTestId("page-toolbar-left")).not.toBeInTheDocument();
+		expect(screen.getByTestId("page-toolbar-middle")).toBeInTheDocument();
+		expect(screen.getByTestId("page-toolbar-right")).toBeInTheDocument();
+	});
+
+	test("omits right zone when not provided", () => {
+		render(<PageToolbar left={<span>L</span>} middle={<span>M</span>} />);
+		expect(screen.getByTestId("page-toolbar-left")).toBeInTheDocument();
+		expect(screen.getByTestId("page-toolbar-middle")).toBeInTheDocument();
+		expect(screen.queryByTestId("page-toolbar-right")).not.toBeInTheDocument();
+	});
+
+	test("always renders middle zone even when middle is omitted", () => {
+		render(<PageToolbar left={<span>L</span>} />);
+		expect(screen.getByTestId("page-toolbar-middle")).toBeInTheDocument();
+	});
+});

--- a/src/components/page-toolbar.tsx
+++ b/src/components/page-toolbar.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+
+interface PageToolbarProps {
+	left?: ReactNode;
+	middle?: ReactNode;
+	right?: ReactNode;
+}
+
+export function PageToolbar({ left, middle, right }: PageToolbarProps) {
+	return (
+		<div
+			className="sticky top-0 z-20 flex shrink-0 items-center gap-md border-b border-border bg-background px-lg py-sm"
+			data-testid="page-toolbar"
+		>
+			{left !== undefined && (
+				<div className="flex shrink-0 items-center gap-sm" data-testid="page-toolbar-left">
+					{left}
+				</div>
+			)}
+			<div className="flex min-w-0 flex-1 items-center" data-testid="page-toolbar-middle">
+				{middle}
+			</div>
+			{right !== undefined && (
+				<div className="flex shrink-0 items-center gap-sm" data-testid="page-toolbar-right">
+					{right}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/settings-layout.tsx
+++ b/src/components/settings-layout.tsx
@@ -1,6 +1,7 @@
-import { Menu, MoveLeft, Plus, UserPlus } from "lucide-react";
+import { Plus, UserPlus } from "lucide-react";
 import { useState } from "react";
-import { Link, Outlet, useLocation, useOutletContext } from "react-router";
+import { Outlet, useLocation, useOutletContext } from "react-router";
+import { PageToolbar } from "@/components/page-toolbar";
 import { Button } from "@/components/ui/button";
 import { DESKTOP_QUERY } from "./folder-sidebar";
 import { SettingsSidebar } from "./settings-sidebar";
@@ -89,26 +90,7 @@ export function SettingsLayout() {
 			className="flex h-full flex-1 flex-col overflow-hidden bg-background text-foreground"
 			data-testid="settings-layout"
 		>
-			<header className="sticky top-0 z-30 flex shrink-0 items-center justify-between gap-md border-b border-border bg-background px-lg py-sm">
-				<div className="flex items-center gap-sm">
-					<Button
-						variant="ghost"
-						size="icon-sm"
-						aria-label="Открыть меню настроек"
-						onClick={() => setOpen(true)}
-						className="shrink-0 md:hidden"
-					>
-						<Menu className="size-4" />
-					</Button>
-					<Button variant="ghost" size="icon-sm" aria-label="Назад" asChild>
-						<Link to="/procurement">
-							<MoveLeft className="size-4" />
-						</Link>
-					</Button>
-					{renderBreadcrumb()}
-				</div>
-				{renderHeaderAction()}
-			</header>
+			<PageToolbar left={renderBreadcrumb()} right={renderHeaderAction()} />
 			<div className="flex min-h-0 flex-1">
 				<SettingsSidebar open={open} onOpenChange={setOpen} />
 				<div className="flex min-w-0 flex-1 flex-col overflow-auto">

--- a/src/components/toolbar.test.tsx
+++ b/src/components/toolbar.test.tsx
@@ -1,10 +1,12 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import type { FilterState, SortState } from "@/data/types";
+import type { FilterState, Folder, SortState } from "@/data/types";
 import { Toolbar } from "./toolbar";
 
 const defaultFilters: FilterState = { deviation: "all", status: "all" };
+const defaultFolders: Folder[] = [];
+const defaultFolderCounts: Record<string, number> = { all: 0, none: 0 };
 
 function renderToolbar(
 	overrides: Partial<{
@@ -21,6 +23,14 @@ function renderToolbar(
 		onFiltersChange: overrides.onFiltersChange ?? vi.fn(),
 		sort: overrides.sort ?? null,
 		onSort: overrides.onSort ?? vi.fn(),
+		folders: defaultFolders,
+		folderCounts: defaultFolderCounts,
+		activeFolder: undefined,
+		onFolderSelect: vi.fn(),
+		onCreateFolder: vi.fn(),
+		onRenameFolder: vi.fn(),
+		onRecolorFolder: vi.fn(),
+		onDeleteFolder: vi.fn(),
 	};
 	return {
 		...render(
@@ -64,7 +74,6 @@ describe("Toolbar", () => {
 		renderToolbar();
 
 		fireEvent.click(screen.getByRole("button", { name: "Фильтры" }));
-		expect(screen.getByText("Все")).toBeInTheDocument();
 		expect(screen.getByText("С переплатой")).toBeInTheDocument();
 		expect(screen.getByText("С экономией")).toBeInTheDocument();
 		expect(screen.getByText("Ожидание аналитики")).toBeInTheDocument();
@@ -99,16 +108,6 @@ describe("Toolbar", () => {
 
 		fireEvent.click(screen.getByRole("button", { name: "Фильтры" }));
 		fireEvent.click(screen.getByText("С переплатой"));
-
-		expect(onFiltersChange).toHaveBeenCalledWith({ deviation: "all", status: "all" });
-	});
-
-	test("Все preset resets all filters", () => {
-		const onFiltersChange = vi.fn();
-		renderToolbar({ filters: { deviation: "overpaying", status: "searching" }, onFiltersChange });
-
-		fireEvent.click(screen.getByRole("button", { name: "Фильтры" }));
-		fireEvent.click(screen.getByText("Все"));
 
 		expect(onFiltersChange).toHaveBeenCalledWith({ deviation: "all", status: "all" });
 	});

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowUp, ArrowUpDown, Download, ListFilter, Plus, Search, X } from "lucide-react";
+import { Archive, ArrowDown, ArrowUp, ArrowUpDown, Download, ListFilter, Plus, Search, X } from "lucide-react";
 import { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -18,6 +18,8 @@ interface ToolbarProps {
 	onSort: (field: SortField) => void;
 	onAddPositions?: () => void;
 	onExport?: () => void;
+	isArchiveView?: boolean;
+	onArchiveToggle?: () => void;
 }
 
 const DEVIATION_PRESETS: { label: string; value: DeviationFilter }[] = [
@@ -58,6 +60,8 @@ export function Toolbar({
 	onSort,
 	onAddPositions,
 	onExport,
+	isArchiveView = false,
+	onArchiveToggle,
 }: ToolbarProps) {
 	const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 	const searchInputRef = useRef<HTMLInputElement>(null);
@@ -239,6 +243,25 @@ export function Toolbar({
 						</div>
 					</PopoverContent>
 				</Popover>
+
+				{onArchiveToggle && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								type="button"
+								variant="ghost"
+								size="icon-sm"
+								aria-label="Архив"
+								aria-pressed={isArchiveView}
+								onClick={onArchiveToggle}
+								className={cn(isArchiveView && "bg-muted text-highlight-foreground")}
+							>
+								<Archive aria-hidden="true" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Архив</TooltipContent>
+					</Tooltip>
+				)}
 
 				<Tooltip>
 					<TooltipTrigger asChild>

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -1,11 +1,11 @@
-import { Archive, ArrowDown, ArrowUp, ArrowUpDown, Download, ListFilter, Plus, Search, X } from "lucide-react";
+import { Archive, ArrowDown, ArrowUp, ArrowUpDown, Download, Plus, Search, X } from "lucide-react";
 import { useRef, useState } from "react";
+import { FiltersPopover } from "@/components/filters-popover";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import type { DeviationFilter, FilterState, SortField, SortState, StatusFilter } from "@/data/types";
-import { STATUS_LABELS } from "@/data/types";
+import type { CompanySummary, FilterState, Folder, SortField, SortState } from "@/data/types";
 import { useMountEffect } from "@/hooks/use-mount-effect";
 import { cn } from "@/lib/utils";
 
@@ -20,19 +20,22 @@ interface ToolbarProps {
 	onExport?: () => void;
 	isArchiveView?: boolean;
 	onArchiveToggle?: () => void;
+	// Folder filter (Категория section)
+	folders: Folder[];
+	folderCounts: Record<string, number>;
+	foldersLoading?: boolean;
+	activeFolder: string | undefined;
+	onFolderSelect: (folder: string | undefined) => void;
+	onCreateFolder: (name: string) => void;
+	onRenameFolder: (id: string, name: string) => void;
+	onRecolorFolder: (id: string, color: string) => void;
+	onDeleteFolder: (id: string) => void;
+	// Company filter (Компания section, conditional)
+	companies?: CompanySummary[];
+	selectedCompany?: string | undefined;
+	onCompanySelect?: (company: string | undefined) => void;
+	showCompanies?: boolean;
 }
-
-const DEVIATION_PRESETS: { label: string; value: DeviationFilter }[] = [
-	{ label: "С переплатой", value: "overpaying" },
-	{ label: "С экономией", value: "saving" },
-];
-
-const STATUS_PRESETS: { label: string; value: StatusFilter }[] = [
-	{ label: STATUS_LABELS.awaiting_analytics, value: "awaiting_analytics" },
-	{ label: STATUS_LABELS.searching, value: "searching" },
-	{ label: STATUS_LABELS.negotiating, value: "negotiating" },
-	{ label: STATUS_LABELS.completed, value: "completed" },
-];
 
 const SORT_FIELD_PRESETS: { label: string; field: SortField }[] = [
 	{ label: "Бюджет в год", field: "annualCost" },
@@ -42,10 +45,6 @@ const SORT_FIELD_PRESETS: { label: string; field: SortField }[] = [
 	{ label: "Отклонение (%)", field: "deviation" },
 	{ label: "Переплата (₽)", field: "overpayment" },
 ];
-
-function hasActiveFilter(filters: FilterState): boolean {
-	return filters.deviation !== "all" || filters.status !== "all";
-}
 
 const FILTER_BTN =
 	"rounded-md px-3 py-1.5 text-left text-sm transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
@@ -62,6 +61,19 @@ export function Toolbar({
 	onExport,
 	isArchiveView = false,
 	onArchiveToggle,
+	folders,
+	folderCounts,
+	foldersLoading,
+	activeFolder,
+	onFolderSelect,
+	onCreateFolder,
+	onRenameFolder,
+	onRecolorFolder,
+	onDeleteFolder,
+	companies,
+	selectedCompany,
+	onCompanySelect,
+	showCompanies,
 }: ToolbarProps) {
 	const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 	const searchInputRef = useRef<HTMLInputElement>(null);
@@ -86,24 +98,6 @@ export function Toolbar({
 		// Flush pending search immediately on collapse
 		clearTimeout(debounceRef.current);
 		onSearchChange(latestQueryRef.current);
-	}
-
-	function handleDeviationClick(value: DeviationFilter) {
-		onFiltersChange({
-			...filters,
-			deviation: filters.deviation === value ? "all" : value,
-		});
-	}
-
-	function handleStatusClick(value: StatusFilter) {
-		onFiltersChange({
-			...filters,
-			status: filters.status === value ? "all" : value,
-		});
-	}
-
-	function handleResetFilters() {
-		onFiltersChange({ deviation: "all", status: "all" });
 	}
 
 	return (
@@ -195,54 +189,23 @@ export function Toolbar({
 					</PopoverContent>
 				</Popover>
 
-				<Popover>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<PopoverTrigger asChild>
-								<Button type="button" variant="ghost" size="icon-sm" aria-label="Фильтры" className="relative">
-									<ListFilter aria-hidden="true" />
-									{hasActiveFilter(filters) && (
-										<span className="absolute -right-1 -top-1 size-2.5 rounded-full bg-primary" />
-									)}
-								</Button>
-							</PopoverTrigger>
-						</TooltipTrigger>
-						<TooltipContent>Фильтры</TooltipContent>
-					</Tooltip>
-					<PopoverContent align="end" className="w-56">
-						<div className="flex flex-col gap-1">
-							<button
-								type="button"
-								className={`${FILTER_BTN} ${!hasActiveFilter(filters) ? FILTER_BTN_ACTIVE : ""}`}
-								onClick={handleResetFilters}
-							>
-								Все
-							</button>
-							<div className="my-1 h-px bg-border" />
-							{DEVIATION_PRESETS.map((preset) => (
-								<button
-									key={preset.value}
-									type="button"
-									className={`${FILTER_BTN} ${filters.deviation === preset.value ? FILTER_BTN_ACTIVE : ""}`}
-									onClick={() => handleDeviationClick(preset.value)}
-								>
-									{preset.label}
-								</button>
-							))}
-							<div className="my-1 h-px bg-border" />
-							{STATUS_PRESETS.map((preset) => (
-								<button
-									key={preset.value}
-									type="button"
-									className={`${FILTER_BTN} ${filters.status === preset.value ? FILTER_BTN_ACTIVE : ""}`}
-									onClick={() => handleStatusClick(preset.value)}
-								>
-									{preset.label}
-								</button>
-							))}
-						</div>
-					</PopoverContent>
-				</Popover>
+				<FiltersPopover
+					filters={filters}
+					onFiltersChange={onFiltersChange}
+					folders={folders}
+					folderCounts={folderCounts}
+					foldersLoading={foldersLoading}
+					activeFolder={activeFolder}
+					onFolderSelect={onFolderSelect}
+					onCreateFolder={onCreateFolder}
+					onRenameFolder={onRenameFolder}
+					onRecolorFolder={onRecolorFolder}
+					onDeleteFolder={onDeleteFolder}
+					companies={companies}
+					selectedCompany={selectedCompany}
+					onCompanySelect={onCompanySelect}
+					showCompanies={showCompanies}
+				/>
 
 				{onArchiveToggle && (
 					<Tooltip>

--- a/src/components/total-count.tsx
+++ b/src/components/total-count.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface TotalCountProps {
+	value: number | undefined;
+	isLoading: boolean;
+	suffix?: string;
+}
+
+export function TotalCount({ value, isLoading, suffix }: TotalCountProps) {
+	if (isLoading || value === undefined) {
+		return <Skeleton className="h-5 w-24" data-testid="total-count-skeleton" />;
+	}
+	const text = suffix ? `Всего: ${value} ${suffix}` : `Всего: ${value}`;
+	return (
+		<span className="text-sm font-medium text-foreground" data-testid="total-count">
+			{text}
+		</span>
+	);
+}

--- a/src/components/user-avatar-menu.test.tsx
+++ b/src/components/user-avatar-menu.test.tsx
@@ -8,7 +8,7 @@ import { _resetWorkspaceStore, _setUserSettings } from "@/data/workspace-mock-da
 import { createTestQueryClient, makeSettings } from "@/test-utils";
 import { UserAvatarMenu } from "./user-avatar-menu";
 
-const MOCK_SETTINGS = makeSettings({ last_name: "Петров", date_joined: "2025-01-15T10:00:00Z" });
+const MOCK_SETTINGS = makeSettings({ first_name: "Станислав", last_name: "Чмелев" });
 
 beforeEach(() => {
 	localStorage.clear();
@@ -34,15 +34,6 @@ function renderMenu(initialEntries = ["/"]) {
 								<UserAvatarMenu />
 								<Routes>
 									<Route path="/settings/profile" element={<div data-testid="settings-profile-page">Profile</div>} />
-									<Route
-										path="/settings/companies"
-										element={<div data-testid="settings-companies-page">Companies</div>}
-									/>
-									<Route
-										path="/settings/employees"
-										element={<div data-testid="settings-employees-page">Employees</div>}
-									/>
-									<Route path="/tasks" element={<div data-testid="tasks-page">Tasks</div>} />
 								</Routes>
 							</>
 						}
@@ -53,22 +44,102 @@ function renderMenu(initialEntries = ["/"]) {
 	);
 }
 
-describe("UserAvatarMenu", () => {
-	test("shows user initials avatar when settings load", async () => {
+describe("UserAvatarMenu trigger", () => {
+	test("shows avatar, formatted name, and chevron", async () => {
 		renderMenu();
 
 		await waitFor(() => {
-			expect(screen.getByText("ИП")).toBeInTheDocument();
+			expect(screen.getByText("СЧ")).toBeInTheDocument();
+		});
+		expect(screen.getByText("Станислав Ч.")).toBeInTheDocument();
+		const trigger = screen.getByRole("button", { name: "Меню пользователя" });
+		expect(trigger.querySelector("svg.lucide-chevron-down")).toBeInTheDocument();
+	});
+
+	test("name renders as '<First> <L>.' when last name is present", async () => {
+		_setUserSettings(makeSettings({ first_name: "Станислав", last_name: "Чмелев" }));
+		renderMenu();
+
+		await waitFor(() => {
+			expect(screen.getByText("Станислав Ч.")).toBeInTheDocument();
 		});
 	});
 
-	test("shows fallback icon before settings load", () => {
+	test("name renders as '<First>' (no dot) when last name is missing", async () => {
+		_setUserSettings(makeSettings({ first_name: "Станислав", last_name: "" }));
+		renderMenu();
+
+		await waitFor(() => {
+			expect(screen.getByText("Станислав")).toBeInTheDocument();
+		});
+		expect(screen.queryByText(/Станислав\s+\./)).not.toBeInTheDocument();
+	});
+
+	test("chevron has aria-hidden", async () => {
+		renderMenu();
+
+		await waitFor(() => {
+			expect(screen.getByText("Станислав Ч.")).toBeInTheDocument();
+		});
+		const trigger = screen.getByRole("button", { name: "Меню пользователя" });
+		const chevron = trigger.querySelector("svg.lucide-chevron-down");
+		expect(chevron).toHaveAttribute("aria-hidden", "true");
+	});
+
+	test("shows fallback avatar (no name) before settings load", () => {
 		vi.spyOn(settingsApi, "fetchSettings").mockReturnValueOnce(new Promise(() => {}));
 
 		renderMenu();
 
 		expect(screen.getByRole("button", { name: "Меню пользователя" })).toBeInTheDocument();
-		expect(screen.queryByText("ИП")).not.toBeInTheDocument();
+		expect(screen.queryByText("СЧ")).not.toBeInTheDocument();
+		expect(screen.queryByText(/Станислав/)).not.toBeInTheDocument();
+	});
+});
+
+describe("UserAvatarMenu dropdown", () => {
+	test("contains only Мой профиль, Сменить тему, Выйти in order", async () => {
+		renderMenu();
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "Меню пользователя" }));
+
+		await waitFor(() => {
+			expect(screen.getByText("Мой профиль")).toBeInTheDocument();
+		});
+
+		const items = screen.getAllByRole("menuitem");
+		const labels = items.map((item) => item.textContent?.replace(/Сменить темуСменить тему/, "Сменить тему").trim());
+		expect(labels).toEqual(["Мой профиль", "Сменить тему", "Выйти"]);
+	});
+
+	test("does not show Компании, Сотрудники, or Задачи entries", async () => {
+		renderMenu();
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "Меню пользователя" }));
+
+		await waitFor(() => {
+			expect(screen.getByText("Мой профиль")).toBeInTheDocument();
+		});
+
+		expect(screen.queryByText("Компании")).not.toBeInTheDocument();
+		expect(screen.queryByText("Сотрудники")).not.toBeInTheDocument();
+		expect(screen.queryByText("Задачи")).not.toBeInTheDocument();
+	});
+
+	test("has a separator below Мой профиль and above Выйти", async () => {
+		renderMenu();
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "Меню пользователя" }));
+
+		await waitFor(() => {
+			expect(screen.getByText("Мой профиль")).toBeInTheDocument();
+		});
+
+		const separators = screen.getAllByRole("separator");
+		expect(separators).toHaveLength(2);
 	});
 
 	test("Мой профиль navigates to /settings/profile", async () => {
@@ -88,85 +159,8 @@ describe("UserAvatarMenu", () => {
 		});
 	});
 
-	test("Компании navigates to /settings/companies", async () => {
-		renderMenu();
-		const user = userEvent.setup();
-
-		await user.click(screen.getByRole("button", { name: "Меню пользователя" }));
-
-		await waitFor(() => {
-			expect(screen.getByText("Компании")).toBeInTheDocument();
-		});
-
-		await user.click(screen.getByText("Компании"));
-
-		await waitFor(() => {
-			expect(screen.getByTestId("settings-companies-page")).toBeInTheDocument();
-		});
-	});
-
-	test("Сотрудники navigates to /settings/employees", async () => {
-		renderMenu();
-		const user = userEvent.setup();
-
-		await user.click(screen.getByRole("button", { name: "Меню пользователя" }));
-
-		await waitFor(() => {
-			expect(screen.getByText("Сотрудники")).toBeInTheDocument();
-		});
-
-		await user.click(screen.getByText("Сотрудники"));
-
-		await waitFor(() => {
-			expect(screen.getByTestId("settings-employees-page")).toBeInTheDocument();
-		});
-	});
-
-	test("Задачи navigates to /tasks", async () => {
-		renderMenu();
-		const user = userEvent.setup();
-
-		await user.click(screen.getByRole("button", { name: "Меню пользователя" }));
-
-		await waitFor(() => {
-			expect(screen.getByText("Задачи")).toBeInTheDocument();
-		});
-
-		await user.click(screen.getByText("Задачи"));
-
-		await waitFor(() => {
-			expect(screen.getByTestId("tasks-page")).toBeInTheDocument();
-		});
-	});
-
-	test("menu items are in correct order: settings → Задачи → theme → Выйти", async () => {
-		renderMenu();
-		const user = userEvent.setup();
-
-		await user.click(screen.getByRole("button", { name: "Меню пользователя" }));
-
-		await waitFor(() => {
-			expect(screen.getByText("Задачи")).toBeInTheDocument();
-		});
-
-		const items = screen.getAllByRole("menuitem");
-		const labels = items.map((item) => item.textContent?.trim());
-
-		expect(labels).toEqual(["Мой профиль", "Компании", "Сотрудники", "Задачи", "Сменить темуСменить тему", "Выйти"]);
-	});
-
-	test("menu shows Сменить тему item", async () => {
-		renderMenu();
-		const user = userEvent.setup();
-
-		await user.click(screen.getByRole("button", { name: "Меню пользователя" }));
-
-		await waitFor(() => {
-			expect(screen.getAllByText("Сменить тему").length).toBeGreaterThan(0);
-		});
-	});
-
-	test("menu shows Выйти item", async () => {
+	test("Выйти has destructive styling and clears tokens", async () => {
+		localStorage.setItem("auth-access-token", "token");
 		renderMenu();
 		const user = userEvent.setup();
 
@@ -175,5 +169,34 @@ describe("UserAvatarMenu", () => {
 		await waitFor(() => {
 			expect(screen.getByText("Выйти")).toBeInTheDocument();
 		});
+
+		const logout = screen.getByText("Выйти").closest('[role="menuitem"]');
+		expect(logout).toHaveAttribute("data-variant", "destructive");
+
+		await user.click(screen.getByText("Выйти"));
+
+		await waitFor(() => {
+			expect(localStorage.getItem("auth-access-token")).toBeNull();
+		});
+	});
+
+	test("Сменить тему toggles dark class and persists to localStorage", async () => {
+		renderMenu();
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: "Меню пользователя" }));
+
+		await waitFor(() => {
+			expect(screen.getAllByText("Сменить тему").length).toBeGreaterThan(0);
+		});
+
+		await user.click(screen.getAllByText("Сменить тему")[0]);
+
+		await waitFor(() => {
+			expect(document.documentElement.classList.contains("dark")).toBe(true);
+		});
+		expect(localStorage.getItem("theme")).toBe("dark");
+
+		document.documentElement.classList.remove("dark");
 	});
 });

--- a/src/components/user-avatar-menu.tsx
+++ b/src/components/user-avatar-menu.tsx
@@ -1,4 +1,4 @@
-import { Building2, CircleUser, ListTodo, LogOut, Moon, Sun, User, Users } from "lucide-react";
+import { ChevronDown, CircleUser, LogOut, Moon, Sun, User } from "lucide-react";
 import { useNavigate } from "react-router";
 import {
 	DropdownMenu,
@@ -19,12 +19,18 @@ interface UserAvatarMenuProps {
 	iconClassName?: string;
 }
 
+function formatTriggerName(firstName: string, lastName: string): string {
+	const initial = lastName.trim().charAt(0);
+	return initial ? `${firstName} ${initial}.` : firstName;
+}
+
 export function UserAvatarMenu({ side = "bottom", align = "end", iconClassName = "size-7" }: UserAvatarMenuProps) {
 	const navigate = useNavigate();
 	const { data: settings } = useSettings();
 
 	const initials = settings ? getInitials(settings.first_name, settings.last_name) : null;
 	const avatarColor = settings ? getAvatarColor(settings.avatar_icon) : "";
+	const displayName = settings ? formatTriggerName(settings.first_name, settings.last_name) : null;
 
 	return (
 		<DropdownMenu>
@@ -32,7 +38,7 @@ export function UserAvatarMenu({ side = "bottom", align = "end", iconClassName =
 				<button
 					type="button"
 					aria-label="Меню пользователя"
-					className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+					className="flex items-center gap-1.5 rounded-md p-1 pr-1.5 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
 				>
 					{initials ? (
 						<span
@@ -47,25 +53,14 @@ export function UserAvatarMenu({ side = "bottom", align = "end", iconClassName =
 					) : (
 						<CircleUser className={iconClassName} />
 					)}
+					{displayName && <span className="text-sm text-foreground">{displayName}</span>}
+					<ChevronDown className="size-4 shrink-0" aria-hidden="true" />
 				</button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent side={side} align={align} className="w-56">
 				<DropdownMenuItem onSelect={() => navigate("/settings/profile")}>
 					<User />
 					Мой профиль
-				</DropdownMenuItem>
-				<DropdownMenuItem onSelect={() => navigate("/settings/companies")}>
-					<Building2 />
-					Компании
-				</DropdownMenuItem>
-				<DropdownMenuItem onSelect={() => navigate("/settings/employees")}>
-					<Users />
-					Сотрудники
-				</DropdownMenuItem>
-				<DropdownMenuSeparator />
-				<DropdownMenuItem onSelect={() => navigate("/tasks")}>
-					<ListTodo />
-					Задачи
 				</DropdownMenuItem>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem

--- a/src/pages/procurement-page.test.tsx
+++ b/src/pages/procurement-page.test.tsx
@@ -393,3 +393,124 @@ describe("ProcurementPage — archive toggle", () => {
 		});
 	});
 });
+
+describe("ProcurementPage — toolbar left zone", () => {
+	test("shows total count reflecting all items when no filters active", async () => {
+		setupHandlers(SINGLE_COMPANY);
+		renderPage();
+
+		await waitFor(() => {
+			expect(screen.getByTestId("total-count")).toHaveTextContent("Всего: 3");
+		});
+	});
+
+	test("total count reflects folder filter scope", async () => {
+		setupHandlers(SINGLE_COMPANY);
+		renderPage(["/procurement?folder=f1"]);
+
+		await waitFor(() => {
+			// Only item i1 is in folder f1
+			expect(screen.getByTestId("total-count")).toHaveTextContent(/Всего:\s*1$/);
+		});
+	});
+
+	test("total count updates when company filter changes", async () => {
+		setupHandlers(MULTI_COMPANIES);
+		renderPage(["/procurement?company=c1"]);
+
+		// Start scoped to Альфа (c1) — 2 items
+		await waitFor(
+			() => {
+				expect(screen.getByTestId("total-count")).toHaveTextContent("Всего: 2");
+			},
+			{ timeout: 3000 },
+		);
+
+		const user = userEvent.setup();
+		// Clear company via chip ×
+		await user.click(screen.getByRole("button", { name: /Снять фильтр компании/ }));
+
+		// All 3 items now visible
+		await waitFor(
+			() => {
+				expect(screen.getByTestId("total-count")).toHaveTextContent("Всего: 3");
+			},
+			{ timeout: 3000 },
+		);
+	});
+
+	test("renders company chip when company filter active", async () => {
+		setupHandlers(MULTI_COMPANIES);
+		renderPage(["/procurement?company=c1"]);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("chip-company")).toBeInTheDocument();
+		});
+		expect(screen.getByTestId("chip-company")).toHaveTextContent("Альфа");
+	});
+
+	test("clicking × on company chip clears only the company param", async () => {
+		setupHandlers(MULTI_COMPANIES);
+		renderPage(["/procurement?company=c1&folder=f1"]);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("chip-company")).toBeInTheDocument();
+			expect(screen.getByTestId("chip-folder")).toBeInTheDocument();
+		});
+
+		const user = userEvent.setup();
+		await user.click(screen.getByRole("button", { name: /Снять фильтр компании/ }));
+
+		await waitFor(() => {
+			expect(screen.queryByTestId("chip-company")).not.toBeInTheDocument();
+		});
+		// Folder chip remains
+		expect(screen.getByTestId("chip-folder")).toBeInTheDocument();
+	});
+
+	test("renders folder chip with color and name when folder filter active", async () => {
+		setupHandlers(SINGLE_COMPANY);
+		renderPage(["/procurement?folder=f1"]);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("chip-folder")).toBeInTheDocument();
+		});
+		expect(screen.getByTestId("chip-folder")).toHaveTextContent("Металлопрокат");
+	});
+
+	test("clicking × on folder chip clears only the folder param", async () => {
+		setupHandlers(MULTI_COMPANIES);
+		renderPage(["/procurement?company=c1&folder=f1"]);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("chip-folder")).toBeInTheDocument();
+		});
+
+		const user = userEvent.setup();
+		await user.click(screen.getByRole("button", { name: /Снять фильтр категории/ }));
+
+		await waitFor(() => {
+			expect(screen.queryByTestId("chip-folder")).not.toBeInTheDocument();
+		});
+		// Company chip remains
+		expect(screen.getByTestId("chip-company")).toBeInTheDocument();
+	});
+
+	test("renders 'Без категории' chip when folder=none", async () => {
+		setupHandlers(SINGLE_COMPANY);
+		renderPage(["/procurement?folder=none"]);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("chip-folder")).toHaveTextContent("Без категории");
+		});
+	});
+
+	test("renders 'Архив' chip when folder=archive", async () => {
+		setupHandlers(SINGLE_COMPANY);
+		renderPage(["/procurement?folder=archive"]);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("chip-folder")).toHaveTextContent("Архив");
+		});
+	});
+});

--- a/src/pages/procurement-page.test.tsx
+++ b/src/pages/procurement-page.test.tsx
@@ -338,3 +338,58 @@ describe("ProcurementPage — item drawer", () => {
 		});
 	});
 });
+
+describe("ProcurementPage — archive toggle", () => {
+	test("archive button appears between filters and download", async () => {
+		setupHandlers(SINGLE_COMPANY);
+		renderPage();
+		await waitForSidebar();
+
+		const filters = screen.getByRole("button", { name: "Фильтры" });
+		const archive = screen.getByRole("button", { name: "Архив" });
+		const download = screen.getByRole("button", { name: "Скачать таблицу" });
+
+		// Compare document order via compareDocumentPosition
+		expect(filters.compareDocumentPosition(archive) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+		expect(archive.compareDocumentPosition(download) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+	});
+
+	test("toggle off-state has aria-pressed=false and no folder param", async () => {
+		setupHandlers(SINGLE_COMPANY);
+		renderPage();
+		await waitForSidebar();
+
+		const archive = screen.getByRole("button", { name: "Архив" });
+		expect(archive).toHaveAttribute("aria-pressed", "false");
+	});
+
+	test("clicking sets folder=archive and aria-pressed=true", async () => {
+		setupHandlers(SINGLE_COMPANY);
+		renderPage();
+		await waitForSidebar();
+
+		const user = userEvent.setup();
+		const archive = screen.getByRole("button", { name: "Архив" });
+		await user.click(archive);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "Архив" })).toHaveAttribute("aria-pressed", "true");
+		});
+	});
+
+	test("clicking while in archive view clears folder param", async () => {
+		setupHandlers(SINGLE_COMPANY);
+		renderPage(["/procurement?folder=archive"]);
+		await waitForSidebar();
+
+		const archive = screen.getByRole("button", { name: "Архив" });
+		expect(archive).toHaveAttribute("aria-pressed", "true");
+
+		const user = userEvent.setup();
+		await user.click(archive);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "Архив" })).toHaveAttribute("aria-pressed", "false");
+		});
+	});
+});

--- a/src/pages/procurement-page.tsx
+++ b/src/pages/procurement-page.tsx
@@ -15,12 +15,14 @@ import { toast } from "sonner";
 import { AddPositionsDialog } from "@/components/add-positions-dialog";
 import { AddPositionsDrawer } from "@/components/add-positions-drawer";
 import { CompanyDrawer, parseCompanyTab } from "@/components/company-drawer";
+import { FilterChip } from "@/components/filter-chip";
 import { DESKTOP_QUERY, LS_SIDEBAR_KEY } from "@/components/folder-sidebar";
 import { PageToolbar } from "@/components/page-toolbar";
 import { ProcurementItemDrawer } from "@/components/procurement-item-drawer";
 import { ProcurementSidebar } from "@/components/procurement-sidebar";
 import { ProcurementTable } from "@/components/procurement-table";
 import { Toolbar } from "@/components/toolbar";
+import { TotalCount } from "@/components/total-count";
 import { Button } from "@/components/ui/button";
 import type {
 	DeviationFilter,
@@ -48,6 +50,7 @@ import {
 	useDeleteItem,
 	useExportItems,
 	useItems,
+	useTotals,
 	useUpdateItem,
 } from "@/data/use-items";
 import { useIsMobile } from "@/hooks/use-is-mobile";
@@ -128,6 +131,8 @@ export function ProcurementPage() {
 		error: itemsError,
 		refetch: refetchItems,
 	} = useItems({ search, filters, sort, folder, company });
+
+	const { data: totals, isLoading: totalsLoading } = useTotals({ search, filters, folder, company });
 
 	// Server-backed folder hooks — scoped to selected company
 	const { data: folders = [], isLoading: foldersLoading } = useFolders(company);
@@ -318,6 +323,38 @@ export function ProcurementPage() {
 		});
 	}
 
+	function handleClearCompanyFilter() {
+		setSearchParams((prev) => {
+			const next = new URLSearchParams(prev);
+			next.delete("company");
+			return next;
+		});
+	}
+
+	function handleClearFolderFilter() {
+		setSearchParams((prev) => {
+			const next = new URLSearchParams(prev);
+			next.delete("folder");
+			return next;
+		});
+	}
+
+	const companyChipLabel = company ? companyMap[company] : undefined;
+
+	let folderChipLabel: string | undefined;
+	let folderChipColor: string | undefined;
+	if (folder === "archive") {
+		folderChipLabel = "Архив";
+	} else if (folder === "none") {
+		folderChipLabel = "Без категории";
+	} else if (folder) {
+		const f = folders.find((ff) => ff.id === folder);
+		if (f) {
+			folderChipLabel = f.name;
+			folderChipColor = f.color;
+		}
+	}
+
 	const toolbar = (
 		<Toolbar
 			defaultSearch={search}
@@ -343,17 +380,37 @@ export function ProcurementPage() {
 			<div className="flex h-full flex-1 flex-col overflow-hidden bg-background text-foreground">
 				<PageToolbar
 					left={
-						isMobile ? (
-							<Button
-								variant="ghost"
-								size="icon-sm"
-								className="shrink-0"
-								onClick={() => setSidebarOpen(true)}
-								aria-label="Открыть боковую панель"
-							>
-								<PanelLeft className="size-4" />
-							</Button>
-						) : undefined
+						<>
+							{isMobile && (
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									className="shrink-0"
+									onClick={() => setSidebarOpen(true)}
+									aria-label="Открыть боковую панель"
+								>
+									<PanelLeft className="size-4" />
+								</Button>
+							)}
+							<TotalCount value={totals?.itemCount} isLoading={totalsLoading} />
+							{companyChipLabel && (
+								<FilterChip
+									testId="chip-company"
+									label={companyChipLabel}
+									onRemove={handleClearCompanyFilter}
+									removeAriaLabel={`Снять фильтр компании ${companyChipLabel}`}
+								/>
+							)}
+							{folderChipLabel && (
+								<FilterChip
+									testId="chip-folder"
+									label={folderChipLabel}
+									color={folderChipColor}
+									onRemove={handleClearFolderFilter}
+									removeAriaLabel={`Снять фильтр категории ${folderChipLabel}`}
+								/>
+							)}
+						</>
 					}
 					middle={toolbar}
 				/>

--- a/src/pages/procurement-page.tsx
+++ b/src/pages/procurement-page.tsx
@@ -367,6 +367,19 @@ export function ProcurementPage() {
 			onExport={handleExport}
 			isArchiveView={isArchiveView}
 			onArchiveToggle={handleArchiveToggle}
+			folders={folders}
+			folderCounts={counts}
+			foldersLoading={foldersLoading || statsLoading}
+			activeFolder={folder}
+			onFolderSelect={handleFolderSelect}
+			onCreateFolder={(name) => createFolderMutation.mutate({ name, color: nextUnusedColor(folders) })}
+			onRenameFolder={(id, name) => updateFolderMutation.mutate({ id, name })}
+			onRecolorFolder={(id, color) => updateFolderMutation.mutate({ id, color })}
+			onDeleteFolder={(id) => deleteFolderMutation.mutate(id)}
+			companies={companies}
+			selectedCompany={company}
+			onCompanySelect={handleCompanySelect}
+			showCompanies={isMultiCompany}
 		/>
 	);
 

--- a/src/pages/procurement-page.tsx
+++ b/src/pages/procurement-page.tsx
@@ -309,6 +309,15 @@ export function ProcurementPage() {
 		});
 	}
 
+	function handleArchiveToggle() {
+		setSearchParams((prev) => {
+			const next = new URLSearchParams(prev);
+			if (next.get("folder") === "archive") next.delete("folder");
+			else next.set("folder", "archive");
+			return next;
+		});
+	}
+
 	const toolbar = (
 		<Toolbar
 			defaultSearch={search}
@@ -319,6 +328,8 @@ export function ProcurementPage() {
 			onSort={handleSort}
 			onAddPositions={() => setDialogOpen(true)}
 			onExport={handleExport}
+			isArchiveView={isArchiveView}
+			onArchiveToggle={handleArchiveToggle}
 		/>
 	);
 

--- a/src/pages/procurement-page.tsx
+++ b/src/pages/procurement-page.tsx
@@ -10,14 +10,13 @@ import {
 } from "@dnd-kit/core";
 import { PanelLeft } from "lucide-react";
 import { useMemo, useState } from "react";
-import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { AddPositionsDialog } from "@/components/add-positions-dialog";
 import { AddPositionsDrawer } from "@/components/add-positions-drawer";
-import { useToolbarPortal } from "@/components/app-layout";
 import { CompanyDrawer, parseCompanyTab } from "@/components/company-drawer";
 import { DESKTOP_QUERY, LS_SIDEBAR_KEY } from "@/components/folder-sidebar";
+import { PageToolbar } from "@/components/page-toolbar";
 import { ProcurementItemDrawer } from "@/components/procurement-item-drawer";
 import { ProcurementSidebar } from "@/components/procurement-sidebar";
 import { ProcurementTable } from "@/components/procurement-table";
@@ -310,9 +309,6 @@ export function ProcurementPage() {
 		});
 	}
 
-	const toolbarPortal = useToolbarPortal();
-	const portalTarget = !isMobile && toolbarPortal ? toolbarPortal : null;
-
 	const toolbar = (
 		<Toolbar
 			defaultSearch={search}
@@ -334,11 +330,9 @@ export function ProcurementPage() {
 			onDragEnd={handleDragEnd}
 		>
 			<div className="flex h-full flex-1 flex-col overflow-hidden bg-background text-foreground">
-				{portalTarget ? (
-					createPortal(toolbar, portalTarget)
-				) : (
-					<header className="sticky top-0 z-20 flex shrink-0 items-center gap-md border-b border-border bg-background px-lg py-sm">
-						{isMobile && (
+				<PageToolbar
+					left={
+						isMobile ? (
 							<Button
 								variant="ghost"
 								size="icon-sm"
@@ -348,10 +342,10 @@ export function ProcurementPage() {
 							>
 								<PanelLeft className="size-4" />
 							</Button>
-						)}
-						{toolbar}
-					</header>
-				)}
+						) : undefined
+					}
+					middle={toolbar}
+				/>
 
 				<div className="flex min-h-0 min-w-0 flex-1">
 					<ProcurementSidebar

--- a/src/pages/tasks-page.test.tsx
+++ b/src/pages/tasks-page.test.tsx
@@ -529,4 +529,26 @@ describe("TasksPage", () => {
 			});
 		});
 	});
+
+	describe("toolbar left zone", () => {
+		it("shows total tasks count with задач suffix", async () => {
+			renderPage();
+
+			await waitFor(() => {
+				expect(screen.getByTestId("total-count")).toHaveTextContent(/Всего:\s*12\s*задач$/);
+			});
+		});
+
+		it("shows skeleton while loading then resolves to count", async () => {
+			renderPage();
+
+			// Skeleton present on first render (before query resolves)
+			expect(screen.getByTestId("total-count-skeleton")).toBeInTheDocument();
+
+			await waitFor(() => {
+				expect(screen.getByTestId("total-count")).toBeInTheDocument();
+			});
+			expect(screen.queryByTestId("total-count-skeleton")).not.toBeInTheDocument();
+		});
+	});
 });

--- a/src/pages/tasks-page.tsx
+++ b/src/pages/tasks-page.tsx
@@ -9,10 +9,9 @@ import {
 	useSensors,
 } from "@dnd-kit/core";
 import { useState } from "react";
-import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router";
 import { toast } from "sonner";
-import { useToolbarPortal } from "@/components/app-layout";
+import { PageToolbar } from "@/components/page-toolbar";
 import { isValidTransition, TaskBoard } from "@/components/task-board";
 import { TaskCard } from "@/components/task-card";
 import { TaskDrawer } from "@/components/task-drawer";
@@ -173,9 +172,6 @@ export function TasksPage() {
 		setPendingDrag(null);
 	}
 
-	const toolbarPortal = useToolbarPortal();
-	const portalTarget = !isMobile && toolbarPortal ? toolbarPortal : null;
-
 	const taskToolbar = (
 		<TaskToolbar
 			defaultSearch={search}
@@ -202,13 +198,7 @@ export function TasksPage() {
 			onDragEnd={handleDragEnd}
 		>
 			<div className="flex h-full flex-1 flex-col overflow-hidden bg-background text-foreground">
-				{portalTarget ? (
-					createPortal(taskToolbar, portalTarget)
-				) : (
-					<header className="sticky top-0 z-20 flex shrink-0 items-center gap-md border-b border-border bg-background px-lg py-sm">
-						{taskToolbar}
-					</header>
-				)}
+				<PageToolbar middle={taskToolbar} />
 				{view === "board" ? (
 					<TaskBoard
 						columns={columns}

--- a/src/pages/tasks-page.tsx
+++ b/src/pages/tasks-page.tsx
@@ -17,6 +17,7 @@ import { TaskCard } from "@/components/task-card";
 import { TaskDrawer } from "@/components/task-drawer";
 import { TaskTable } from "@/components/task-table";
 import { TaskToolbar } from "@/components/task-toolbar";
+import { TotalCount } from "@/components/total-count";
 import type { Task, TaskFilterParams, TaskSortField, TaskStatus } from "@/data/task-types";
 import { TASK_STATUSES } from "@/data/task-types";
 import { useProcurementCompanies } from "@/data/use-companies";
@@ -68,6 +69,11 @@ export function TasksPage() {
 
 	const columns = useTaskColumns(filterParams);
 	const updateStatus = useUpdateTaskStatus();
+
+	const taskTotalLoading = columns.assigned.isLoading;
+	const taskTotal = taskTotalLoading
+		? undefined
+		: columns.assigned.count + columns.in_progress.count + columns.completed.count + columns.archived.count;
 
 	// Drag state
 	const [reducedMotion] = useState(() => window.matchMedia("(prefers-reduced-motion: reduce)").matches);
@@ -198,7 +204,10 @@ export function TasksPage() {
 			onDragEnd={handleDragEnd}
 		>
 			<div className="flex h-full flex-1 flex-col overflow-hidden bg-background text-foreground">
-				<PageToolbar middle={taskToolbar} />
+				<PageToolbar
+					left={<TotalCount value={taskTotal} isLoading={taskTotalLoading} suffix="задач" />}
+					middle={taskToolbar}
+				/>
 				{view === "board" ? (
 					<TaskBoard
 						columns={columns}


### PR DESCRIPTION
Sixth slice of nav refactor PRD #214. Rebuilds the procurement Фильтры popover as a single sectioned popover with Компания, Категория, Отклонение, and Статус sections. Folder CRUD (create / rename / recolor / delete) moves into the Категория section. The folder sidebar remains as a parallel path until #222.

## Summary

- `filters-popover.tsx` (new): single sectioned popover. Компания (conditional on `showCompanies && onCompanySelect`) → Категория → Отклонение → Статус. Folder rows have color dots + per-folder counts; hover kebab opens Переименовать (inline edit), color grid (8 FOLDER_COLORS), Удалить (AlertDialog confirm). Inline `+ Новая категория` row.
- `toolbar.tsx`: drops the inline deviation/status popover and its "Все" reset; forwards folder + company props straight to `FiltersPopover`. Trigger, tooltip, and active-filter dot indicator preserved.
- `procurement-page.tsx`: wires existing `useFolders`/`useFolderStats` + mutation hooks + `useProcurementCompanies` into `Toolbar`. No new query; popover and sidebar share the same hooks and URL state.

Nested Radix layering — the FolderRow mounts a DropdownMenu + an AlertDialog inside the outer Popover; DismissableLayer stacks correctly, verified by the delete/cancel tests.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm build` — clean
- [x] `pnpm test` — 1207 tests passing (up from 1170, +37 net: 38 new filters-popover, -1 removed "Все" preset test)
- [x] Section visibility: hidden Компания in single-company, shown in multi-company, correct DOM order
- [x] Компания: name + count render, click selects, click-again clears, active highlight
- [x] Категория: system rows (Все закупки / Без категории) + folder rows with color dots + counts; loading skeletons; click selects with correct id
- [x] Folder CRUD: create (Enter/Esc), rename (preload + Enter/Esc), recolor (8 dots + check on active), delete (AlertDialog confirm + cancel + active-folder reset)
- [x] Отклонение + Статус: presets toggle on/off, active highlight
- [x] Trigger dot reflects `deviation !== "all" || status !== "all"`
- [x] Folder sidebar path continues to work unchanged (parallel during refactor)

Closes #219. Unblocks #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)